### PR TITLE
refactor(视图控制): 重构缩放和平移实现以提升性能

### DIFF
--- a/MainWindow/MainWindow.Architecture.cs
+++ b/MainWindow/MainWindow.Architecture.cs
@@ -81,12 +81,12 @@ namespace WindBoard
                 CanvasHost.RenderTransform = group;
             }
 
-            _zoomPanService = new ZoomPanService(Viewport, ZoomTransform, _panTransform, MinZoom, MaxZoom, zoom => _strokeService.UpdatePenThickness(zoom));
+            _zoomPanService = new ZoomPanService(ZoomTransform, _panTransform, MinZoom, MaxZoom, zoom => _strokeService.UpdatePenThickness(zoom));
             _strokeService.SetStrokeThicknessConsistencyEnabled(
                 SettingsService.Instance.GetStrokeThicknessConsistencyEnabled(),
                 _zoomPanService.Zoom);
-            _pageService = new PageService(MyCanvas, Viewport, _zoomPanService, NotifyPageUiChanged);
-            _autoExpandService = new AutoExpandService(MyCanvas, Viewport, _zoomPanService, () => _pageService.CurrentPage, () => _inkMode?.HasActiveStroke ?? false);
+            _pageService = new PageService(MyCanvas, _zoomPanService, NotifyPageUiChanged);
+            _autoExpandService = new AutoExpandService(MyCanvas, _zoomPanService, () => _pageService.CurrentPage, () => _inkMode?.HasActiveStroke ?? false);
 
             _inkMode = new InkMode(MyCanvas, () => _zoomPanService.Zoom, OnInkStrokeEndedOrCanceled);
             _selectMode = new SelectMode(MyCanvas);

--- a/MainWindow/MainWindow.Architecture.cs
+++ b/MainWindow/MainWindow.Architecture.cs
@@ -49,6 +49,7 @@ namespace WindBoard
         private DispatcherTimer? _viewportCacheDisableTimer;
         private BitmapCache? _viewportBitmapCache;
         private StrokeCollection? _undoObservedStrokes;
+        private readonly TranslateTransform _panTransform = new TranslateTransform();
 
         private InkMode? _inkMode;
         private EraserMode? _eraserMode;
@@ -68,7 +69,19 @@ namespace WindBoard
 
             _modeController = new ModeController();
             _strokeService = new StrokeService(MyCanvas, _baseThickness);
-            _zoomPanService = new ZoomPanService(Viewport, ZoomTransform, MinZoom, MaxZoom, zoom => _strokeService.UpdatePenThickness(zoom));
+
+            // 性能：避免使用 LayoutTransform（会触发布局）；改用 RenderTransform 实现“相机式”缩放/平移。
+            // XAML 中仍声明了 ZoomTransform（原用于 LayoutTransform），这里在运行时将其移到 RenderTransform。
+            if (CanvasHost != null)
+            {
+                CanvasHost.LayoutTransform = null;
+                var group = new TransformGroup();
+                group.Children.Add(ZoomTransform);
+                group.Children.Add(_panTransform);
+                CanvasHost.RenderTransform = group;
+            }
+
+            _zoomPanService = new ZoomPanService(Viewport, ZoomTransform, _panTransform, MinZoom, MaxZoom, zoom => _strokeService.UpdatePenThickness(zoom));
             _strokeService.SetStrokeThicknessConsistencyEnabled(
                 SettingsService.Instance.GetStrokeThicknessConsistencyEnabled(),
                 _zoomPanService.Zoom);

--- a/MainWindow/MainWindow.UI.cs
+++ b/MainWindow/MainWindow.UI.cs
@@ -134,13 +134,21 @@ namespace WindBoard
 
             Dispatcher.InvokeAsync(() =>
             {
-                Viewport.UpdateLayout();
+                // 运行时缩放/拖动使用 RenderTransform，不再依赖 ScrollViewer offset。
+                // 初始化时将画布中心对齐到视口中心。
+                double viewportW = Viewport.ActualWidth;
+                double viewportH = Viewport.ActualHeight;
+                if (viewportW <= 0 || viewportH <= 0)
+                {
+                    Viewport.UpdateLayout();
+                    viewportW = Viewport.ActualWidth;
+                    viewportH = Viewport.ActualHeight;
+                }
 
-                var extentW = MyCanvas.Width * _zoomPanService.Zoom;
-                var extentH = MyCanvas.Height * _zoomPanService.Zoom;
-
-                Viewport.ScrollToHorizontalOffset((extentW - Viewport.ViewportWidth) / 2.0);
-                Viewport.ScrollToVerticalOffset((extentH - Viewport.ViewportHeight) / 2.0);
+                double zoom = _zoomPanService.Zoom;
+                double panX = viewportW / 2.0 - (MyCanvas.Width / 2.0) * zoom;
+                double panY = viewportH / 2.0 - (MyCanvas.Height / 2.0) * zoom;
+                _zoomPanService.SetPanDirect(panX, panY);
 
                 _strokeService.UpdatePenThickness(_zoomPanService.Zoom);
 

--- a/Models/BoardPage.cs
+++ b/Models/BoardPage.cs
@@ -45,8 +45,8 @@ namespace WindBoard
 
         // 每页视图状态（可选但体验更好）
         public double Zoom { get; set; } = 1.0;
-        public double HorizontalOffset { get; set; } = 0.0;
-        public double VerticalOffset { get; set; } = 0.0;
+        public double PanX { get; set; } = 0.0;
+        public double PanY { get; set; } = 0.0;
 
         private void OnPropertyChanged([CallerMemberName] string? name = null)
             => PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(name ?? string.Empty));

--- a/Services/AutoExpandService.cs
+++ b/Services/AutoExpandService.cs
@@ -11,7 +11,7 @@ namespace WindBoard.Services
     public class AutoExpandService
     {
         private readonly InkCanvas _canvas;
-        private readonly ScrollViewer _viewport;
+        private readonly FrameworkElement _viewport;
         private readonly ZoomPanService _zoomPanService;
         private readonly Func<BoardPage?> _currentPageProvider;
         private readonly Func<bool>? _isInkingActiveProvider;
@@ -19,7 +19,7 @@ namespace WindBoard.Services
         private double _pendingShiftX;
         private double _pendingShiftY;
 
-        public AutoExpandService(InkCanvas canvas, ScrollViewer viewport, ZoomPanService zoomPanService, Func<BoardPage?> currentPageProvider, Func<bool>? isInkingActiveProvider = null)
+        public AutoExpandService(InkCanvas canvas, FrameworkElement viewport, ZoomPanService zoomPanService, Func<BoardPage?> currentPageProvider, Func<bool>? isInkingActiveProvider = null)
         {
             _canvas = canvas;
             _viewport = viewport;
@@ -114,9 +114,10 @@ namespace WindBoard.Services
                 InkCanvas.SetTop(child, top + dy);
             }
 
-            _viewport.UpdateLayout();
-            _viewport.ScrollToHorizontalOffset(_viewport.HorizontalOffset + dx * _zoomPanService.Zoom);
-            _viewport.ScrollToVerticalOffset(_viewport.VerticalOffset + dy * _zoomPanService.Zoom);
+            // 内容整体右/下平移后，为了保持用户视野不跳动，需要将相机做反向补偿。
+            _zoomPanService.SetPanDirect(
+                _zoomPanService.PanX - dx * _zoomPanService.Zoom,
+                _zoomPanService.PanY - dy * _zoomPanService.Zoom);
         }
     }
 }

--- a/Services/AutoExpandService.cs
+++ b/Services/AutoExpandService.cs
@@ -11,7 +11,6 @@ namespace WindBoard.Services
     public class AutoExpandService
     {
         private readonly InkCanvas _canvas;
-        private readonly FrameworkElement _viewport;
         private readonly ZoomPanService _zoomPanService;
         private readonly Func<BoardPage?> _currentPageProvider;
         private readonly Func<bool>? _isInkingActiveProvider;
@@ -19,10 +18,9 @@ namespace WindBoard.Services
         private double _pendingShiftX;
         private double _pendingShiftY;
 
-        public AutoExpandService(InkCanvas canvas, FrameworkElement viewport, ZoomPanService zoomPanService, Func<BoardPage?> currentPageProvider, Func<bool>? isInkingActiveProvider = null)
+        public AutoExpandService(InkCanvas canvas, ZoomPanService zoomPanService, Func<BoardPage?> currentPageProvider, Func<bool>? isInkingActiveProvider = null)
         {
             _canvas = canvas;
-            _viewport = viewport;
             _zoomPanService = zoomPanService;
             _currentPageProvider = currentPageProvider;
             _isInkingActiveProvider = isInkingActiveProvider;

--- a/Services/PageService.cs
+++ b/Services/PageService.cs
@@ -10,7 +10,7 @@ namespace WindBoard.Services
     public class PageService
     {
         private readonly InkCanvas _canvas;
-        private readonly ScrollViewer _viewport;
+        private readonly FrameworkElement _viewport;
         private readonly ZoomPanService _zoomPanService;
         private readonly Action? _onPageStateChanged;
 
@@ -21,7 +21,7 @@ namespace WindBoard.Services
 
         public ObservableCollection<BoardPage> Pages { get; } = new ObservableCollection<BoardPage>();
 
-        public PageService(InkCanvas canvas, ScrollViewer viewport, ZoomPanService zoomPanService, Action? onPageStateChanged = null)
+        public PageService(InkCanvas canvas, FrameworkElement viewport, ZoomPanService zoomPanService, Action? onPageStateChanged = null)
         {
             _canvas = canvas;
             _viewport = viewport;
@@ -46,8 +46,8 @@ namespace WindBoard.Services
                 CanvasWidth = _canvas.Width,
                 CanvasHeight = _canvas.Height,
                 Zoom = _zoomPanService.Zoom,
-                HorizontalOffset = _viewport.HorizontalOffset,
-                VerticalOffset = _viewport.VerticalOffset,
+                PanX = _zoomPanService.PanX,
+                PanY = _zoomPanService.PanY,
                 Strokes = _canvas.Strokes
             };
 
@@ -66,8 +66,8 @@ namespace WindBoard.Services
             cur.CanvasWidth = _canvas.Width;
             cur.CanvasHeight = _canvas.Height;
             cur.Zoom = _zoomPanService.Zoom;
-            cur.HorizontalOffset = _viewport.HorizontalOffset;
-            cur.VerticalOffset = _viewport.VerticalOffset;
+            cur.PanX = _zoomPanService.PanX;
+            cur.PanY = _zoomPanService.PanY;
 
             // 重要：不要 Clone 当前页笔迹。InkCanvas 与当前页共享同一个 StrokeCollection，
             // 否则在“页面管理/切页”时会产生常驻双份笔迹，导致内存暴涨且无法回落。
@@ -98,8 +98,8 @@ namespace WindBoard.Services
                 CanvasWidth = 8000,
                 CanvasHeight = 8000,
                 Zoom = _zoomPanService.Zoom,
-                HorizontalOffset = 0,
-                VerticalOffset = 0,
+                PanX = 0,
+                PanY = 0,
                 Strokes = new StrokeCollection()
             };
 
@@ -177,11 +177,7 @@ namespace WindBoard.Services
                 _canvas.Strokes = page.Strokes ?? new StrokeCollection();
                 AttachStrokeEvents();
 
-                _zoomPanService.SetZoomDirect(page.Zoom);
-
-                _viewport.UpdateLayout();
-                _viewport.ScrollToHorizontalOffset(page.HorizontalOffset);
-                _viewport.ScrollToVerticalOffset(page.VerticalOffset);
+                _zoomPanService.SetViewDirect(page.Zoom, page.PanX, page.PanY);
             }
             finally
             {

--- a/Services/PageService.cs
+++ b/Services/PageService.cs
@@ -10,7 +10,6 @@ namespace WindBoard.Services
     public class PageService
     {
         private readonly InkCanvas _canvas;
-        private readonly FrameworkElement _viewport;
         private readonly ZoomPanService _zoomPanService;
         private readonly Action? _onPageStateChanged;
 
@@ -21,10 +20,9 @@ namespace WindBoard.Services
 
         public ObservableCollection<BoardPage> Pages { get; } = new ObservableCollection<BoardPage>();
 
-        public PageService(InkCanvas canvas, FrameworkElement viewport, ZoomPanService zoomPanService, Action? onPageStateChanged = null)
+        public PageService(InkCanvas canvas, ZoomPanService zoomPanService, Action? onPageStateChanged = null)
         {
             _canvas = canvas;
-            _viewport = viewport;
             _zoomPanService = zoomPanService;
             _onPageStateChanged = onPageStateChanged;
 

--- a/Services/ZoomPanService.cs
+++ b/Services/ZoomPanService.cs
@@ -1,14 +1,12 @@
 using System;
 using System.Collections.Generic;
 using System.Windows;
-using System.Windows.Controls;
 using System.Windows.Media;
 
 namespace WindBoard.Services
 {
     public class ZoomPanService
     {
-        private readonly FrameworkElement _viewport;
         private readonly ScaleTransform _zoomTransform;
         private readonly double _minZoom;
         private readonly double _maxZoom;
@@ -30,9 +28,8 @@ namespace WindBoard.Services
         public bool IsMousePanning => _isMousePanning;
         public bool IsGestureActive => _gestureActive;
 
-        public ZoomPanService(FrameworkElement viewport, ScaleTransform zoomTransform, TranslateTransform panTransform, double minZoom = 0.5, double maxZoom = 5.0, Action<double>? onZoomChanged = null)
+        public ZoomPanService(ScaleTransform zoomTransform, TranslateTransform panTransform, double minZoom = 0.5, double maxZoom = 5.0, Action<double>? onZoomChanged = null)
         {
-            _viewport = viewport;
             _zoomTransform = zoomTransform;
             _panTransform = panTransform;
             _minZoom = minZoom;


### PR DESCRIPTION
将基于 ScrollViewer 的视图控制改为使用 RenderTransform 实现
- 重命名 Horizontal/VerticalOffset 为 PanX/PanY 以更准确描述功能
- 使用 TranslateTransform 实现平移，避免 ScrollViewer 布局计算开销
- 优化手势处理逻辑，减少不必要的布局更新
- 修改相关服务接口以适配新的视图控制方式

## Summary by Sourcery

重构缩放和平移系统，改为使用渲染变换（render transforms）而非 ScrollViewer 偏移量，并更新相关服务和页面状态以适配新的“相机”视图模型。

Enhancements:
- 将基于 ScrollViewer 的平移替换为基于 `TranslateTransform` 的平移，并与现有的 `ScaleTransform` 组合，实现相机风格的缩放/平移。
- 引入显式的 `PanX`/`PanY` 状态，以及 `SetViewDirect` 帮助方法，用于统一管理缩放与平移的组合更新。
- 在启动时使用新的平移模型将画布居中到视口中，并将画布的变换从 `LayoutTransform` 迁移到 `RenderTransform`。
- 调整自动扩展行为，在画布位移后通过补偿相机平移而不是滚动来实现。
- 优化手写笔输入处理，通过在每个数据包中重用 `InputEventArgs` 并跳过未使用的压感读取，减少分配和跨层开销。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refactor the zoom and pan system to use render transforms instead of ScrollViewer offsets, updating related services and page state to work with the new camera-style view model.

Enhancements:
- Replace ScrollViewer-based panning with a TranslateTransform-based pan tied to an existing ScaleTransform for camera-style zoom/pan.
- Introduce explicit PanX/PanY state and a SetViewDirect helper to manage combined zoom and pan updates.
- Center the canvas within the viewport on startup using the new pan model and migrate canvas transforms from LayoutTransform to RenderTransform.
- Adjust auto-expand behavior to compensate camera pan instead of scrolling after canvas shifts.
- Optimize stylus input handling by reusing InputEventArgs per packet and skipping unused pressure reads to reduce allocations and cross-layer overhead.

</details>