### PR TITLE
添加测试

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,37 +1,23 @@
 # Repository Guidelines
 
-## Project Overview
-WindBoard is a Windows-only WPF whiteboard app built on `.NET 10` with MaterialDesignThemes (Material Design 3). Most changes are UI/interaction-heavy; please include repro steps and screenshots when you touch XAML or styling.
-
 ## Project Structure & Module Organization
-- `Core/`: input pipeline, interaction modes, ink smoothing/filters.
-- `Views/`: WPF views and controls (`*.xaml` + `*.xaml.cs`), including `MainWindow.xaml`.
-- `MainWindow/`: main window logic split by concern (UI, pages, input pipeline).
-- `Services/`: app services (pages, settings, preview rendering, strokes, zoom/pan).
-- `Models/`: small data models.
-- `Styles/` and `Resources/`: XAML styles and assets (e.g., `Resources/Fonts/*.ttf`).
+WindBoard is a Windows-only WPF whiteboard app targeting .NET 10 with MaterialDesignThemes (Material Design 3). Key folders: `Core/` (input pipeline, interaction modes, ink smoothing and filters), `Services/` (pages, strokes, zoom/pan, settings, preview rendering), `MainWindow/` (UI, pages, input pipeline split by concern), `Views/` (XAML views/controls, including `MainWindow.xaml`), `Styles/` and `Resources/` (XAML styles, fonts), and `Models/` (lightweight data models). Build artifacts live in `bin/` and `obj/`; settings are written to `%APPDATA%\WindBoard\settings.json` (do not commit).
 
 ## Build, Test, and Development Commands
-Run from the repo root:
-- `dotnet restore`: restore NuGet packages.
-- `dotnet build -c Debug`: build the solution.
-- `dotnet run --project WindBoard.csproj`: run the WPF app.
-- `dotnet build -c Release`: produce release binaries (also works via Visual Studio 2022+).
+- `dotnet restore` – restore NuGet packages.
+- `dotnet build -c Debug` – build the solution for local development.
+- `dotnet run --project WindBoard.csproj` – launch the WPF app.
+- `dotnet build -c Release` – create release binaries.  
+Run commands from the repo root. Visual Studio 2022+ or VS Code works; the project targets `net10.0-windows10.0.26100.0`.
 
 ## Coding Style & Naming Conventions
-- Indentation: 4 spaces in C#; keep XAML attributes readable and wrap long lines.
-- Naming: `PascalCase` for types/methods, `camelCase` for locals/fields; keep folders aligned with domain (`Core/*`, `Services/*`, `Views/*`).
-- Nullability is enabled (`<Nullable>enable</Nullable>`); prefer fixing warnings over suppressing them.
-- `.editorconfig` currently only tunes `CS8622` severity—use your IDE/VS formatting defaults for consistency.
+Use 4-space indentation in C#; keep XAML attributes readable and wrap long lines. Naming: `PascalCase` for types/methods/properties/events, `camelCase` for locals/fields/parameters. Nullability is enabled; prefer fixing warnings over suppressing them. Stick to the existing folder topology (Core/Services/MainWindow/Views). Follow Material Design 3 patterns already present in XAML. `.editorconfig` only downgrades CS8622 to suggestion—otherwise use default .NET formatting.
 
 ## Testing Guidelines
-There is no dedicated automated test project today. For changes:
-- Add clear manual verification steps (device type if relevant: mouse/pen/touch).
-- For UI changes, attach screenshots or short clips and note display scaling (100%/125%/150%).
+There is no automated test project yet. Manually verify the whiteboard with the relevant input device (mouse/pen/touch) and note display scaling (e.g., 100%/125%/150%). For UI or styling changes, include repro steps and screenshots or short clips. Try to cover drawing, erase, select, page navigation, zoom/pan, and attachments when they are affected.
 
 ## Commit & Pull Request Guidelines
-- Commit messages follow “conventional commit” style: `feat:`, `fix:`, `refactor:`, optionally scoped like `feat(UI): ...`.
-- PRs should include: summary, motivation/linked issue, manual test steps, and screenshots for visual changes. Keep PRs focused; avoid unrelated refactors.
+Use conventional commits (`feat:`, `fix:`, `refactor:`, optionally scoped like `feat(UI): …`). Keep PRs focused and describe the motivation/linked issue. Include a brief summary of changes, manual test steps (per device), and screenshots for visual changes. Avoid unrelated refactors in the same PR.
 
 ## Security & Configuration Tips
-- User settings are persisted to `%APPDATA%\\WindBoard\\settings.json`; avoid committing local settings or machine-specific paths.
+User settings persist to `%APPDATA%\WindBoard\settings.json`; avoid committing local config or machine-specific paths. Respect bundled assets under `Resources/` and `Styles/`. If you add fonts or binaries, ensure licensing is compatible with Apache 2.0.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,7 +19,7 @@
 
 ## Coding Style & Naming Conventions
 - C# with nullable enabled; prefer explicit types and guard clauses for null-sensitive code paths.
-- Indent with 4 spaces; keep using statements sorted and scoped minimal.
+- Indent with 4 spaces; keep using statements sorted and scoped minimally.
 - PascalCase for types/methods/properties; camelCase for locals/parameters; `_camelCase` for private fields when needed.
 - Favor small, single-responsibility methods; continue splitting large code-behind into partial classes under `MainWindow/`.
 - When adding styles or resources, place shared entries in `Styles/` or `Resources/Fonts/` and reference via XAML resource keys.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,23 +1,37 @@
 # Repository Guidelines
 
 ## Project Structure & Module Organization
-WindBoard is a Windows-only WPF whiteboard app targeting .NET 10 with MaterialDesignThemes (Material Design 3). Key folders: `Core/` (input pipeline, interaction modes, ink smoothing and filters), `Services/` (pages, strokes, zoom/pan, settings, preview rendering), `MainWindow/` (UI, pages, input pipeline split by concern), `Views/` (XAML views/controls, including `MainWindow.xaml`), `Styles/` and `Resources/` (XAML styles, fonts), and `Models/` (lightweight data models). Build artifacts live in `bin/` and `obj/`; settings are written to `%APPDATA%\WindBoard\settings.json` (do not commit).
+- `Core/`: input pipeline, ink smoothing (`Ink/`), stylus adapters (`Input/`), and mode logic (`Modes/`).
+- `Services/`: page, stroke, zoom/pan, settings persistence, and auxiliary behaviors (camouflage, auto-expand).
+- `MainWindow/`: partial classes split by concern (architecture, attachments, input pipeline, pages, UI glue).
+- `Models/`: board page, attachments, and import request types.
+- `Views/`: XAML views and controls (dialogs, page navigator, windows) plus backing code-behind.
+- `Styles/` and `Resources/`: shared styles and fonts.
+- `WindBoard.Tests/`: xUnit test suites organized by domain (`Ink/`, `Services/`); keep new tests colocated.
+- `docs/`: user-facing docs; prefer adding architecture notes here when relevant.
 
 ## Build, Test, and Development Commands
-- `dotnet restore` – restore NuGet packages.
-- `dotnet build -c Debug` – build the solution for local development.
-- `dotnet run --project WindBoard.csproj` – launch the WPF app.
-- `dotnet build -c Release` – create release binaries.  
-Run commands from the repo root. Visual Studio 2022+ or VS Code works; the project targets `net10.0-windows10.0.26100.0`.
+- `dotnet restore` — restore NuGet packages.
+- `dotnet build WindBoard.sln` — compile app and tests (target `net10.0-windows10.0.26100.0` with WPF).
+- `dotnet run --project WindBoard.csproj` — launch the WPF app.
+- `dotnet test WindBoard.sln` — run all xUnit tests; add `-p:CollectCoverage=true` to emit coverage via coverlet.
+- `dotnet format` — keep C# formatting consistent before sending a PR.
 
 ## Coding Style & Naming Conventions
-Use 4-space indentation in C#; keep XAML attributes readable and wrap long lines. Naming: `PascalCase` for types/methods/properties/events, `camelCase` for locals/fields/parameters. Nullability is enabled; prefer fixing warnings over suppressing them. Stick to the existing folder topology (Core/Services/MainWindow/Views). Follow Material Design 3 patterns already present in XAML. `.editorconfig` only downgrades CS8622 to suggestion—otherwise use default .NET formatting.
+- C# with nullable enabled; prefer explicit types and guard clauses for null-sensitive code paths.
+- Indent with 4 spaces; keep using statements sorted and scoped minimal.
+- PascalCase for types/methods/properties; camelCase for locals/parameters; `_camelCase` for private fields when needed.
+- Favor small, single-responsibility methods; continue splitting large code-behind into partial classes under `MainWindow/`.
+- When adding styles or resources, place shared entries in `Styles/` or `Resources/Fonts/` and reference via XAML resource keys.
 
 ## Testing Guidelines
-There is no automated test project yet. Manually verify the whiteboard with the relevant input device (mouse/pen/touch) and note display scaling (e.g., 100%/125%/150%). For UI or styling changes, include repro steps and screenshots or short clips. Try to cover drawing, erase, select, page navigation, zoom/pan, and attachments when they are affected.
+- Framework: xUnit with `StaFact` for WPF-affecting tests; reuse the existing `ClassName_MethodUnderTest_ExpectedOutcome` naming pattern.
+- Keep test fixtures under the matching domain folder (e.g., `WindBoard.Tests/Ink` for ink algorithms).
+- For input/ink behaviors, construct `InkCanvas`, `StrokeCollection`, and `StylusPointCollection` as shown in current tests; assert both state and side effects (e.g., page content versions, stroke collections).
+- Aim to cover new services or modes with positive, boundary, and undo/redo scenarios; prefer deterministic data over randomness.
 
 ## Commit & Pull Request Guidelines
-Use conventional commits (`feat:`, `fix:`, `refactor:`, optionally scoped like `feat(UI): …`). Keep PRs focused and describe the motivation/linked issue. Include a brief summary of changes, manual test steps (per device), and screenshots for visual changes. Avoid unrelated refactors in the same PR.
-
-## Security & Configuration Tips
-User settings persist to `%APPDATA%\WindBoard\settings.json`; avoid committing local config or machine-specific paths. Respect bundled assets under `Resources/` and `Styles/`. If you add fonts or binaries, ensure licensing is compatible with Apache 2.0.
+- Follow the existing Conventional-Commit style (`feat:`, `refactor:`, etc.); keep messages concise and scoped to one change.
+- Ensure `dotnet build` and `dotnet test` pass before opening a PR; include relevant test additions.
+- PR description should summarize behavior change, affected modules, and user-visible impact; link issues when available.
+- Include screenshots or short clips for UI-affecting changes (dialogs, controls, or new gestures).

--- a/AssemblyInfo.cs
+++ b/AssemblyInfo.cs
@@ -1,4 +1,5 @@
 using System.Windows;
+using System.Runtime.CompilerServices;
 
 [assembly:ThemeInfo(
     ResourceDictionaryLocation.None,            //where theme specific resource dictionaries are located
@@ -8,3 +9,5 @@ using System.Windows;
                                                 //(used if a resource is not found in the page,
                                                 // app, or any theme specific resource dictionaries)
 )]
+
+[assembly: InternalsVisibleTo("WindBoard.Tests")]

--- a/WindBoard.Tests/AssemblyInfo.cs
+++ b/WindBoard.Tests/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+using Xunit;
+
+[assembly: CollectionBehavior(DisableTestParallelization = true)]

--- a/WindBoard.Tests/AssemblyInfo.cs
+++ b/WindBoard.Tests/AssemblyInfo.cs
@@ -1,3 +1,4 @@
 using Xunit;
 
+// WPF/STA-bound tests need a shared single-threaded dispatcher; keep parallelization off unless UI threading constraints are addressed.
 [assembly: CollectionBehavior(DisableTestParallelization = true)]

--- a/WindBoard.Tests/Ink/InkSmoothingDefaultsTests.cs
+++ b/WindBoard.Tests/Ink/InkSmoothingDefaultsTests.cs
@@ -1,13 +1,12 @@
 using System.Windows;
 using WindBoard.Core.Ink;
 using Xunit;
+using static WindBoard.Tests.TestHelpers.InkTestHelpers;
 
 namespace WindBoard.Tests.Ink;
 
 public sealed class InkSmoothingDefaultsTests
 {
-    private const double DipPerMm = 96.0 / 25.4;
-
     [Fact]
     public void ForContact_WhenNullContact_ReturnsPenDefaults()
     {
@@ -93,4 +92,3 @@ public sealed class InkSmoothingDefaultsTests
         Assert.Equal(expected.EpsilonCornerMm, actual.EpsilonCornerMm, precision: 12);
     }
 }
-

--- a/WindBoard.Tests/Ink/InkSmoothingDefaultsTests.cs
+++ b/WindBoard.Tests/Ink/InkSmoothingDefaultsTests.cs
@@ -1,0 +1,96 @@
+using System.Windows;
+using WindBoard.Core.Ink;
+using Xunit;
+
+namespace WindBoard.Tests.Ink;
+
+public sealed class InkSmoothingDefaultsTests
+{
+    private const double DipPerMm = 96.0 / 25.4;
+
+    [Fact]
+    public void ForContact_WhenNullContact_ReturnsPenDefaults()
+    {
+        var actual = InkSmoothingDefaults.ForContact(contactSizeCanvasDip: null, zoom: 1.0);
+
+        var expected = new InkSmoothingParameters(
+            StepMm: 1.1,
+            EpsilonMm: 0.22,
+            FcMin: 2.2,
+            Beta: 0.045,
+            DCutoff: 1.2,
+            VStopMmPerSec: 18,
+            StopHoldMs: 60,
+            FcSticky: 0.8,
+            CornerAngleDeg: 120,
+            CornerHoldMs: 80,
+            FcCorner: 18,
+            EpsilonCornerMm: 0.18);
+
+        AssertParametersEqual(expected, actual);
+    }
+
+    [Fact]
+    public void ForContact_WhenLargeContact_ReturnsFingerDefaults()
+    {
+        var sizeDip = new Size(31, 31);
+        var actual = InkSmoothingDefaults.ForContact(contactSizeCanvasDip: sizeDip, zoom: 1.0);
+
+        var expected = new InkSmoothingParameters(
+            StepMm: 1.3,
+            EpsilonMm: 0.4,
+            FcMin: 1.6,
+            Beta: 0.028,
+            DCutoff: 1.2,
+            VStopMmPerSec: 18,
+            StopHoldMs: 60,
+            FcSticky: 0.8,
+            CornerAngleDeg: 120,
+            CornerHoldMs: 80,
+            FcCorner: 18,
+            EpsilonCornerMm: 0.22);
+
+        AssertParametersEqual(expected, actual);
+    }
+
+    [Fact]
+    public void ForContact_WhenMidContact_LerpsBetweenPenAndFinger()
+    {
+        const double sizeMm = 6.5;
+        var sizeDip = new Size(sizeMm * DipPerMm, sizeMm * DipPerMm);
+        var actual = InkSmoothingDefaults.ForContact(contactSizeCanvasDip: sizeDip, zoom: 1.0);
+
+        var expected = new InkSmoothingParameters(
+            StepMm: 1.2,
+            EpsilonMm: 0.31,
+            FcMin: 1.9,
+            Beta: 0.0365,
+            DCutoff: 1.2,
+            VStopMmPerSec: 18,
+            StopHoldMs: 60,
+            FcSticky: 0.8,
+            CornerAngleDeg: 120,
+            CornerHoldMs: 80,
+            FcCorner: 18,
+            EpsilonCornerMm: 0.2);
+
+        AssertParametersEqual(expected, actual);
+    }
+
+    private static void AssertParametersEqual(InkSmoothingParameters expected, InkSmoothingParameters actual)
+    {
+        Assert.Equal(expected.StepMm, actual.StepMm, precision: 12);
+        Assert.Equal(expected.EpsilonMm, actual.EpsilonMm, precision: 12);
+        Assert.Equal(expected.FcMin, actual.FcMin, precision: 12);
+        Assert.Equal(expected.Beta, actual.Beta, precision: 12);
+        Assert.Equal(expected.DCutoff, actual.DCutoff, precision: 12);
+        Assert.Equal(expected.VStopMmPerSec, actual.VStopMmPerSec, precision: 12);
+        Assert.Equal(expected.StopHoldMs, actual.StopHoldMs);
+        Assert.Equal(expected.FcSticky, actual.FcSticky, precision: 12);
+        Assert.Equal(expected.CornerAngleDeg, actual.CornerAngleDeg, precision: 12);
+        Assert.Equal(expected.CornerHoldMs, actual.CornerHoldMs);
+        Assert.Equal(expected.FcCorner, actual.FcCorner, precision: 12);
+        Assert.Equal(expected.EpsilonCornerMm, actual.EpsilonCornerMm, precision: 12);
+    }
+}
+

--- a/WindBoard.Tests/Ink/OneEuroFilter2DTests.cs
+++ b/WindBoard.Tests/Ink/OneEuroFilter2DTests.cs
@@ -1,0 +1,51 @@
+using System;
+using System.Windows;
+using WindBoard.Core.Ink;
+using Xunit;
+
+namespace WindBoard.Tests.Ink;
+
+public sealed class OneEuroFilter2DTests
+{
+    [Fact]
+    public void Update_FirstCall_ResetsAndReturnsInput()
+    {
+        var filter = new OneEuroFilter2D();
+        var p = new Point(10, 20);
+
+        var result = filter.Update(
+            rawMm: p,
+            dtSec: 0.016,
+            minCutoffHz: 2,
+            beta: 0.1,
+            dCutoffHz: 1);
+
+        Assert.Equal(p, result);
+        Assert.Equal(0, filter.DerivativeMagnitudeMmPerSec, precision: 12);
+    }
+
+    [Fact]
+    public void Update_DoesNotThrow_WhenCutoffClampReversed()
+    {
+        var filter = new OneEuroFilter2D();
+        filter.Reset(new Point(0, 0));
+
+        var ex = Record.Exception(() =>
+        {
+            filter.Update(
+                rawMm: new Point(1, 0),
+                dtSec: 0.0,
+                minCutoffHz: 2.0,
+                beta: 0.0,
+                dCutoffHz: 1.0,
+                cutoffMinClampHz: 10.0,
+                cutoffMaxClampHz: 1.0);
+        });
+
+        Assert.Null(ex);
+        Assert.True(filter.DerivativeMagnitudeMmPerSec >= 0);
+        Assert.False(double.IsNaN(filter.DerivativeMagnitudeMmPerSec));
+        Assert.False(double.IsInfinity(filter.DerivativeMagnitudeMmPerSec));
+    }
+}
+

--- a/WindBoard.Tests/Ink/RealtimeInkSmootherTests.cs
+++ b/WindBoard.Tests/Ink/RealtimeInkSmootherTests.cs
@@ -1,0 +1,52 @@
+using System;
+using System.Windows;
+using WindBoard.Core.Ink;
+using Xunit;
+
+namespace WindBoard.Tests.Ink;
+
+public sealed class RealtimeInkSmootherTests
+{
+    private const double DipPerMm = 96.0 / 25.4;
+
+    [StaFact]
+    public void Process_DoesNotThrow_WhenCornerAndStickyOverlap()
+    {
+        var parameters = new InkSmoothingParameters(
+            StepMm: 0.05,
+            EpsilonMm: 0.001,
+            FcMin: 2.2,
+            Beta: 0.045,
+            DCutoff: 1.2,
+            VStopMmPerSec: 18,
+            StopHoldMs: 60,
+            FcSticky: 0.8,
+            CornerAngleDeg: 120,
+            CornerHoldMs: 80,
+            FcCorner: 18,
+            EpsilonCornerMm: 0.001);
+
+        var smoother = new RealtimeInkSmoother(parameters);
+        const double zoom = 1.0;
+
+        long ticks = 0;
+        smoother.Process(ToDip(0, 0), ticks, zoom, isFinal: false);
+
+        ticks += 50 * TimeSpan.TicksPerMillisecond;
+        smoother.Process(ToDip(0.05, 0), ticks, zoom, isFinal: false);
+
+        ticks += 50 * TimeSpan.TicksPerMillisecond;
+        smoother.Process(ToDip(0.10, 0), ticks, zoom, isFinal: false);
+
+        ticks += 50 * TimeSpan.TicksPerMillisecond;
+        smoother.Process(ToDip(0.10, 0.05), ticks, zoom, isFinal: false);
+
+        ticks += 50 * TimeSpan.TicksPerMillisecond;
+        var output = smoother.Process(ToDip(0.10, 0.10), ticks, zoom, isFinal: true);
+
+        Assert.NotEmpty(output);
+
+        Point ToDip(double xMm, double yMm) => new(xMm * DipPerMm / zoom, yMm * DipPerMm / zoom);
+    }
+}
+

--- a/WindBoard.Tests/Ink/RealtimeInkSmootherTests.cs
+++ b/WindBoard.Tests/Ink/RealtimeInkSmootherTests.cs
@@ -2,13 +2,12 @@ using System;
 using System.Windows;
 using WindBoard.Core.Ink;
 using Xunit;
+using static WindBoard.Tests.TestHelpers.InkTestHelpers;
 
 namespace WindBoard.Tests.Ink;
 
 public sealed class RealtimeInkSmootherTests
 {
-    private const double DipPerMm = 96.0 / 25.4;
-
     [StaFact]
     public void Process_DoesNotThrow_WhenCornerAndStickyOverlap()
     {
@@ -49,4 +48,3 @@ public sealed class RealtimeInkSmootherTests
         Point ToDip(double xMm, double yMm) => new(xMm * DipPerMm / zoom, yMm * DipPerMm / zoom);
     }
 }
-

--- a/WindBoard.Tests/Ink/SimulatedPressureConfigTests.cs
+++ b/WindBoard.Tests/Ink/SimulatedPressureConfigTests.cs
@@ -1,0 +1,60 @@
+using WindBoard.Core.Ink;
+using Xunit;
+
+namespace WindBoard.Tests.Ink;
+
+public sealed class SimulatedPressureConfigTests
+{
+    [Fact]
+    public void ClampInPlace_SwapsSpeedRange_WhenMaxBelowMin()
+    {
+        var cfg = new SimulatedPressureConfig
+        {
+            SpeedMinMmPerSec = 1000,
+            SpeedMaxMmPerSec = 10
+        };
+
+        cfg.ClampInPlace();
+
+        Assert.True(cfg.SpeedMinMmPerSec <= cfg.SpeedMaxMmPerSec);
+        Assert.Equal(10, cfg.SpeedMinMmPerSec, precision: 12);
+        Assert.Equal(1000, cfg.SpeedMaxMmPerSec, precision: 12);
+    }
+
+    [Fact]
+    public void ClampInPlace_ClampsFloors_AndKeepsEndFloorNotAboveFloor()
+    {
+        var cfg = new SimulatedPressureConfig
+        {
+            PressureFloor = 0.2f,
+            EndPressureFloor = 0.9f
+        };
+
+        cfg.ClampInPlace();
+
+        Assert.Equal(cfg.PressureFloor, cfg.EndPressureFloor);
+        Assert.InRange(cfg.PressureFloor, 0.02f, 1.0f);
+    }
+
+    [Fact]
+    public void Clone_CreatesIndependentCopy()
+    {
+        var cfg = new SimulatedPressureConfig
+        {
+            Enabled = false,
+            StartTaperMm = 1.23,
+            MaxEndTaperPoints = 42
+        };
+
+        var clone = cfg.Clone();
+
+        Assert.NotSame(cfg, clone);
+        Assert.Equal(cfg.Enabled, clone.Enabled);
+        Assert.Equal(cfg.StartTaperMm, clone.StartTaperMm, precision: 12);
+        Assert.Equal(cfg.MaxEndTaperPoints, clone.MaxEndTaperPoints);
+
+        clone.MaxEndTaperPoints = 99;
+        Assert.Equal(42, cfg.MaxEndTaperPoints);
+    }
+}
+

--- a/WindBoard.Tests/Ink/StrokeThicknessMetadataTests.cs
+++ b/WindBoard.Tests/Ink/StrokeThicknessMetadataTests.cs
@@ -1,7 +1,7 @@
 using System.Windows.Ink;
-using System.Windows.Input;
 using WindBoard.Core.Ink;
 using Xunit;
+using static WindBoard.Tests.TestHelpers.InkTestHelpers;
 
 namespace WindBoard.Tests.Ink;
 
@@ -40,15 +40,4 @@ public sealed class StrokeThicknessMetadataTests
 
         Assert.False(StrokeThicknessMetadata.TryGetLogicalThicknessDip(stroke, out _));
     }
-
-    private static Stroke CreateStroke()
-    {
-        var points = new StylusPointCollection
-        {
-            new StylusPoint(0, 0),
-            new StylusPoint(1, 1)
-        };
-        return new Stroke(points);
-    }
 }
-

--- a/WindBoard.Tests/Ink/StrokeThicknessMetadataTests.cs
+++ b/WindBoard.Tests/Ink/StrokeThicknessMetadataTests.cs
@@ -1,0 +1,54 @@
+using System.Windows.Ink;
+using System.Windows.Input;
+using WindBoard.Core.Ink;
+using Xunit;
+
+namespace WindBoard.Tests.Ink;
+
+public sealed class StrokeThicknessMetadataTests
+{
+    [StaFact]
+    public void SetLogicalThicknessDip_ThenTryGet_ReturnsTrueAndSameValue()
+    {
+        var stroke = CreateStroke();
+
+        StrokeThicknessMetadata.SetLogicalThicknessDip(stroke, 3.5);
+
+        Assert.True(StrokeThicknessMetadata.TryGetLogicalThicknessDip(stroke, out var thickness));
+        Assert.Equal(3.5, thickness, precision: 12);
+    }
+
+    [StaFact]
+    public void GetOrCreateLogicalThicknessDip_UsesDrawingAttributesAndZoom_AndPersistsToStroke()
+    {
+        var stroke = CreateStroke();
+        stroke.DrawingAttributes.Width = 2;
+        stroke.DrawingAttributes.Height = 4;
+
+        var logical = StrokeThicknessMetadata.GetOrCreateLogicalThicknessDip(stroke, currentZoom: 2.0);
+
+        Assert.Equal(6.0, logical, precision: 12);
+        Assert.True(StrokeThicknessMetadata.TryGetLogicalThicknessDip(stroke, out var stored));
+        Assert.Equal(logical, stored, precision: 12);
+    }
+
+    [StaFact]
+    public void TryGetLogicalThicknessDip_ReturnsFalse_ForInvalidStoredValue()
+    {
+        var stroke = CreateStroke();
+        stroke.AddPropertyData(StrokeThicknessMetadata.LogicalThicknessDipPropertyId, "not-a-number");
+
+        Assert.False(StrokeThicknessMetadata.TryGetLogicalThicknessDip(stroke, out _));
+    }
+
+    private static Stroke CreateStroke()
+    {
+        var points = new StylusPointCollection
+        {
+            new StylusPoint(0, 0),
+            new StylusPoint(1, 1)
+        };
+        return new Stroke(points);
+    }
+}
+

--- a/WindBoard.Tests/Services/PageServiceTests.cs
+++ b/WindBoard.Tests/Services/PageServiceTests.cs
@@ -1,0 +1,76 @@
+using System.Windows.Controls;
+using System.Windows.Ink;
+using System.Windows.Input;
+using System.Windows.Media;
+using WindBoard.Services;
+using Xunit;
+
+namespace WindBoard.Tests.Services;
+
+public sealed class PageServiceTests
+{
+    [StaFact]
+    public void InitializePagesIfNeeded_CreatesSingleCurrentPage_SharingCanvasStrokes()
+    {
+        var canvas = new InkCanvas { Width = 8000, Height = 6000, Strokes = new StrokeCollection() };
+        var zoomPan = new ZoomPanService(new ScaleTransform(1, 1), new TranslateTransform(0, 0));
+        var svc = new PageService(canvas, zoomPan);
+
+        svc.InitializePagesIfNeeded();
+
+        Assert.Single(svc.Pages);
+        Assert.Equal(0, svc.CurrentPageIndex);
+        Assert.NotNull(svc.CurrentPage);
+        Assert.True(svc.CurrentPage!.IsCurrent);
+        Assert.Same(canvas.Strokes, svc.CurrentPage.Strokes);
+        Assert.Equal("1 / 1", svc.PageIndicatorText);
+    }
+
+    [StaFact]
+    public void AddPage_SwitchesToNewPage_AndCanvasUsesNewStrokeCollection()
+    {
+        var canvas = new InkCanvas { Width = 8000, Height = 6000, Strokes = new StrokeCollection() };
+        var zoomPan = new ZoomPanService(new ScaleTransform(1, 1), new TranslateTransform(0, 0));
+        var svc = new PageService(canvas, zoomPan);
+        svc.InitializePagesIfNeeded();
+        var firstStrokes = canvas.Strokes;
+
+        svc.AddPage();
+
+        Assert.Equal(2, svc.Pages.Count);
+        Assert.Equal(1, svc.CurrentPageIndex);
+        Assert.True(svc.IsMultiPage);
+        Assert.NotSame(firstStrokes, canvas.Strokes);
+        Assert.Same(canvas.Strokes, svc.CurrentPage!.Strokes);
+        Assert.Equal("2 / 2", svc.PageIndicatorText);
+        Assert.True(svc.Pages[1].IsCurrent);
+        Assert.False(svc.Pages[0].IsCurrent);
+    }
+
+    [StaFact]
+    public void StrokeChanges_IncrementCurrentPageContentVersion()
+    {
+        var canvas = new InkCanvas { Width = 8000, Height = 6000, Strokes = new StrokeCollection() };
+        var zoomPan = new ZoomPanService(new ScaleTransform(1, 1), new TranslateTransform(0, 0));
+        var svc = new PageService(canvas, zoomPan);
+        svc.InitializePagesIfNeeded();
+
+        var page = svc.CurrentPage!;
+        int before = page.ContentVersion;
+
+        canvas.Strokes.Add(CreateStroke());
+
+        Assert.True(page.ContentVersion > before);
+    }
+
+    private static Stroke CreateStroke()
+    {
+        var points = new StylusPointCollection
+        {
+            new StylusPoint(0, 0),
+            new StylusPoint(1, 1)
+        };
+        return new Stroke(points);
+    }
+}
+

--- a/WindBoard.Tests/Services/PageServiceTests.cs
+++ b/WindBoard.Tests/Services/PageServiceTests.cs
@@ -1,9 +1,9 @@
 using System.Windows.Controls;
 using System.Windows.Ink;
-using System.Windows.Input;
 using System.Windows.Media;
 using WindBoard.Services;
 using Xunit;
+using static WindBoard.Tests.TestHelpers.InkTestHelpers;
 
 namespace WindBoard.Tests.Services;
 
@@ -62,15 +62,4 @@ public sealed class PageServiceTests
 
         Assert.True(page.ContentVersion > before);
     }
-
-    private static Stroke CreateStroke()
-    {
-        var points = new StylusPointCollection
-        {
-            new StylusPoint(0, 0),
-            new StylusPoint(1, 1)
-        };
-        return new Stroke(points);
-    }
 }
-

--- a/WindBoard.Tests/Services/StrokeUndoHistoryTests.cs
+++ b/WindBoard.Tests/Services/StrokeUndoHistoryTests.cs
@@ -1,7 +1,7 @@
 using System.Windows.Ink;
-using System.Windows.Input;
 using WindBoard.Services;
 using Xunit;
+using static WindBoard.Tests.TestHelpers.InkTestHelpers;
 
 namespace WindBoard.Tests.Services;
 
@@ -62,15 +62,5 @@ public sealed class StrokeUndoHistoryTests
         }
 
         Assert.False(history.CanUndo);
-    }
-
-    private static Stroke CreateStroke()
-    {
-        var points = new StylusPointCollection
-        {
-            new StylusPoint(0, 0),
-            new StylusPoint(1, 1)
-        };
-        return new Stroke(points);
     }
 }

--- a/WindBoard.Tests/Services/StrokeUndoHistoryTests.cs
+++ b/WindBoard.Tests/Services/StrokeUndoHistoryTests.cs
@@ -1,0 +1,76 @@
+using System.Windows.Ink;
+using System.Windows.Input;
+using WindBoard.Services;
+using Xunit;
+
+namespace WindBoard.Tests.Services;
+
+public sealed class StrokeUndoHistoryTests
+{
+    [StaFact]
+    public void Transaction_AddStroke_CanUndoUndoRedo()
+    {
+        var strokes = new StrokeCollection();
+        var history = new StrokeUndoHistory();
+        strokes.StrokesChanged += (_, e) => history.Record(e);
+
+        history.Begin();
+        var s1 = CreateStroke();
+        strokes.Add(s1);
+        history.End();
+
+        Assert.True(history.CanUndo);
+        Assert.Contains(s1, strokes);
+
+        history.Undo(strokes);
+        Assert.DoesNotContain(s1, strokes);
+        Assert.True(history.CanRedo);
+
+        history.Redo(strokes);
+        Assert.Contains(s1, strokes);
+    }
+
+    [StaFact]
+    public void Transaction_AddThenRemoveSameStroke_ProducesNoUndo()
+    {
+        var strokes = new StrokeCollection();
+        var history = new StrokeUndoHistory();
+        strokes.StrokesChanged += (_, e) => history.Record(e);
+
+        history.Begin();
+        var s1 = CreateStroke();
+        strokes.Add(s1);
+        strokes.Remove(s1);
+        history.End();
+
+        Assert.False(history.CanUndo);
+        Assert.DoesNotContain(s1, strokes);
+    }
+
+    [StaFact]
+    public void SuspendRecording_PreventsTransactionsFromBeingCaptured()
+    {
+        var strokes = new StrokeCollection();
+        var history = new StrokeUndoHistory();
+        strokes.StrokesChanged += (_, e) => history.Record(e);
+
+        using (history.SuspendRecording())
+        {
+            history.Begin();
+            strokes.Add(CreateStroke());
+            history.End();
+        }
+
+        Assert.False(history.CanUndo);
+    }
+
+    private static Stroke CreateStroke()
+    {
+        var points = new StylusPointCollection
+        {
+            new StylusPoint(0, 0),
+            new StylusPoint(1, 1)
+        };
+        return new Stroke(points);
+    }
+}

--- a/WindBoard.Tests/Services/ZoomPanServiceTests.cs
+++ b/WindBoard.Tests/Services/ZoomPanServiceTests.cs
@@ -1,0 +1,71 @@
+using System.Windows;
+using System.Windows.Media;
+using WindBoard.Services;
+using Xunit;
+
+namespace WindBoard.Tests.Services;
+
+public sealed class ZoomPanServiceTests
+{
+    [StaFact]
+    public void ZoomAt_KeepsViewportPointAnchored()
+    {
+        var zoomTransform = new ScaleTransform(1, 1);
+        var panTransform = new TranslateTransform(0, 0);
+        var svc = new ZoomPanService(zoomTransform, panTransform, minZoom: 0.5, maxZoom: 5.0);
+
+        svc.ZoomAt(new Point(100, 50), newZoom: 2.0);
+
+        Assert.Equal(2.0, svc.Zoom, precision: 12);
+        Assert.Equal(-100.0, svc.PanX, precision: 12);
+        Assert.Equal(-50.0, svc.PanY, precision: 12);
+        Assert.Equal(svc.Zoom, zoomTransform.ScaleX, precision: 12);
+        Assert.Equal(svc.PanX, panTransform.X, precision: 12);
+    }
+
+    [StaFact]
+    public void SetZoomDirect_ClampsToMax()
+    {
+        var zoomTransform = new ScaleTransform(1, 1);
+        var panTransform = new TranslateTransform(0, 0);
+        var svc = new ZoomPanService(zoomTransform, panTransform, minZoom: 0.5, maxZoom: 2.0);
+
+        svc.SetZoomDirect(10.0);
+
+        Assert.Equal(2.0, svc.Zoom, precision: 12);
+    }
+
+    [StaFact]
+    public void MousePan_UpdatesPanAndState()
+    {
+        var zoomTransform = new ScaleTransform(1, 1);
+        var panTransform = new TranslateTransform(0, 0);
+        var svc = new ZoomPanService(zoomTransform, panTransform);
+
+        svc.BeginMousePan(new Point(10, 10));
+        Assert.True(svc.IsMousePanning);
+
+        Assert.True(svc.UpdateMousePan(new Point(20, 25)));
+        Assert.Equal(10.0, svc.PanX, precision: 12);
+        Assert.Equal(15.0, svc.PanY, precision: 12);
+
+        svc.EndMousePan();
+        Assert.False(svc.IsMousePanning);
+    }
+
+    [StaFact]
+    public void TouchGesture_TwoTouches_ActivatesGestureAndUpdatesZoom()
+    {
+        var zoomTransform = new ScaleTransform(1, 1);
+        var panTransform = new TranslateTransform(0, 0);
+        var svc = new ZoomPanService(zoomTransform, panTransform, minZoom: 0.5, maxZoom: 5.0);
+
+        Assert.False(svc.TouchDown(1, new Point(0, 0)));
+        Assert.True(svc.TouchDown(2, new Point(100, 0)));
+        Assert.True(svc.IsGestureActive);
+
+        Assert.True(svc.TouchMove(2, new Point(200, 0)));
+        Assert.True(svc.Zoom > 1.0);
+    }
+}
+

--- a/WindBoard.Tests/TestHelpers/InkTestHelpers.cs
+++ b/WindBoard.Tests/TestHelpers/InkTestHelpers.cs
@@ -1,0 +1,20 @@
+using System.Windows.Ink;
+using System.Windows.Input;
+
+namespace WindBoard.Tests.TestHelpers;
+
+internal static class InkTestHelpers
+{
+    public const double DipPerMm = 96.0 / 25.4;
+
+    public static Stroke CreateStroke()
+    {
+        var points = new StylusPointCollection
+        {
+            new StylusPoint(0, 0),
+            new StylusPoint(1, 1)
+        };
+
+        return new Stroke(points);
+    }
+}

--- a/WindBoard.Tests/WindBoard.Tests.csproj
+++ b/WindBoard.Tests/WindBoard.Tests.csproj
@@ -1,0 +1,27 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0-windows10.0.26100.0</TargetFramework>
+    <UseWPF>true</UseWPF>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.4" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
+    <PackageReference Include="Xunit.StaFact" Version="1.2.69" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.7" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\WindBoard.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/WindBoard.csproj
+++ b/WindBoard.csproj
@@ -19,4 +19,9 @@
     <Resource Include="resources\fonts\*.ttf" />
   </ItemGroup>
 
+  <ItemGroup>
+    <Compile Remove="WindBoard.Tests\\**\\*.cs" />
+    <None Remove="WindBoard.Tests\\**\\*" />
+  </ItemGroup>
+
 </Project>

--- a/WindBoard.sln
+++ b/WindBoard.sln
@@ -1,19 +1,46 @@
+﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.5.2.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WindBoard", "WindBoard.csproj", "{47D8A8AC-BD94-434A-C6D0-64E600FB2646}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WindBoard.Tests", "WindBoard.Tests\WindBoard.Tests.csproj", "{8EF5D1D9-81CD-44F6-B89A-E22F781E96BA}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
 		Release|Any CPU = Release|Any CPU
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{47D8A8AC-BD94-434A-C6D0-64E600FB2646}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{47D8A8AC-BD94-434A-C6D0-64E600FB2646}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{47D8A8AC-BD94-434A-C6D0-64E600FB2646}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{47D8A8AC-BD94-434A-C6D0-64E600FB2646}.Debug|x64.Build.0 = Debug|Any CPU
+		{47D8A8AC-BD94-434A-C6D0-64E600FB2646}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{47D8A8AC-BD94-434A-C6D0-64E600FB2646}.Debug|x86.Build.0 = Debug|Any CPU
 		{47D8A8AC-BD94-434A-C6D0-64E600FB2646}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{47D8A8AC-BD94-434A-C6D0-64E600FB2646}.Release|Any CPU.Build.0 = Release|Any CPU
+		{47D8A8AC-BD94-434A-C6D0-64E600FB2646}.Release|x64.ActiveCfg = Release|Any CPU
+		{47D8A8AC-BD94-434A-C6D0-64E600FB2646}.Release|x64.Build.0 = Release|Any CPU
+		{47D8A8AC-BD94-434A-C6D0-64E600FB2646}.Release|x86.ActiveCfg = Release|Any CPU
+		{47D8A8AC-BD94-434A-C6D0-64E600FB2646}.Release|x86.Build.0 = Release|Any CPU
+		{8EF5D1D9-81CD-44F6-B89A-E22F781E96BA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{8EF5D1D9-81CD-44F6-B89A-E22F781E96BA}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{8EF5D1D9-81CD-44F6-B89A-E22F781E96BA}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{8EF5D1D9-81CD-44F6-B89A-E22F781E96BA}.Debug|x64.Build.0 = Debug|Any CPU
+		{8EF5D1D9-81CD-44F6-B89A-E22F781E96BA}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{8EF5D1D9-81CD-44F6-B89A-E22F781E96BA}.Debug|x86.Build.0 = Debug|Any CPU
+		{8EF5D1D9-81CD-44F6-B89A-E22F781E96BA}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{8EF5D1D9-81CD-44F6-B89A-E22F781E96BA}.Release|Any CPU.Build.0 = Release|Any CPU
+		{8EF5D1D9-81CD-44F6-B89A-E22F781E96BA}.Release|x64.ActiveCfg = Release|Any CPU
+		{8EF5D1D9-81CD-44F6-B89A-E22F781E96BA}.Release|x64.Build.0 = Release|Any CPU
+		{8EF5D1D9-81CD-44F6-B89A-E22F781E96BA}.Release|x86.ActiveCfg = Release|Any CPU
+		{8EF5D1D9-81CD-44F6-B89A-E22F781E96BA}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
## Summary by Sourcery

引入一个专门的基于 xUnit 的测试项目和测试指引，同时公开测试覆盖所需的内部成员。

Enhancements:
- 通过 `InternalsVisibleTo` 将内部类型暴露给 `WindBoard.Tests` 项目，以实现更深入的测试覆盖。

Build:
- 将 `WindBoard.Tests` 项目接入解决方案，使其能与主应用程序一起构建和运行。

Documentation:
- 更新 `AGENTS.md`，说明新的项目结构、测试工作流，以及组织和编写测试的约定。

Tests:
- 新增 `WindBoard.Tests` 项目，包含 xUnit 测试，覆盖墨迹平滑默认值、模拟压感配置、笔画粗细元数据、实时墨迹平滑、OneEuro 滤波、页面管理、笔画撤销历史，以及缩放/平移行为。
- 在程序集级别禁用并行测试执行，以避免与 WPF 相关的并发问题。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce a dedicated xUnit-based test project and testing guidance while exposing internals needed for test coverage.

Enhancements:
- Expose internal types to the WindBoard.Tests project via InternalsVisibleTo to enable deeper test coverage.

Build:
- Wire up the WindBoard.Tests project and solution so it builds and runs alongside the main application.

Documentation:
- Refresh AGENTS.md to describe the updated project structure, testing workflow, and conventions for organizing and writing tests.

Tests:
- Add WindBoard.Tests project with xUnit tests covering ink smoothing defaults, simulated pressure config, stroke thickness metadata, realtime ink smoothing, OneEuro filtering, page management, stroke undo history, and zoom/pan behavior.
- Disable parallel test execution at the assembly level to avoid WPF-related concurrency issues.

</details>