### PR TITLE
Develop

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -107,7 +107,7 @@ Services are stateful business logic components initialized in `MainWindow.Archi
 
 - **PageService**: Multi-page management, current page tracking, page preview rendering
 - **StrokeService**: Pen thickness management with zoom-consistency option
-- **ZoomPanService**: Handles mouse wheel zoom, touch gestures, space+drag panning
+- **ZoomPanService**: Handles mouse wheel zoom, touch gestures, right-button drag panning
 - **AutoExpandService**: Automatically expands canvas when drawing near edges
 - **TouchGestureService**: Touch gesture recognition (deprecated, functionality moved to ZoomPanService)
 - **SettingsService**: JSON-based settings persistence to local file

--- a/MainWindow/MainWindow.Architecture.cs
+++ b/MainWindow/MainWindow.Architecture.cs
@@ -77,6 +77,7 @@ namespace WindBoard
             }
 
             _zoomPanService = new ZoomPanService(ZoomTransform, _panTransform, MinZoom, MaxZoom, zoom => _strokeService.UpdatePenThickness(zoom));
+            try { _zoomPanService.TwoFingerOnly = SettingsService.Instance.GetZoomPanTwoFingerOnly(); } catch { }
             _strokeService.SetStrokeThicknessConsistencyEnabled(
                 SettingsService.Instance.GetStrokeThicknessConsistencyEnabled(),
                 _zoomPanService.Zoom);

--- a/MainWindow/MainWindow.Architecture.cs
+++ b/MainWindow/MainWindow.Architecture.cs
@@ -77,7 +77,7 @@ namespace WindBoard
             }
 
             _zoomPanService = new ZoomPanService(ZoomTransform, _panTransform, MinZoom, MaxZoom, zoom => _strokeService.UpdatePenThickness(zoom));
-            try { _zoomPanService.TwoFingerOnly = SettingsService.Instance.GetZoomPanTwoFingerOnly(); } catch { }
+            ApplyZoomPanGestureSettingsSnapshot();
             _strokeService.SetStrokeThicknessConsistencyEnabled(
                 SettingsService.Instance.GetStrokeThicknessConsistencyEnabled(),
                 _zoomPanService.Zoom);

--- a/MainWindow/MainWindow.Attachments.Selection.cs
+++ b/MainWindow/MainWindow.Attachments.Selection.cs
@@ -222,7 +222,6 @@ namespace WindBoard
         {
             if (!IsSelectModeActive()) return false;
             if (e.ChangedButton != MouseButton.Left) return false;
-            if (Keyboard.IsKeyDown(Key.Space)) return false;
 
             var canvasPoint = e.GetPosition(MyCanvas);
             var hit = HitTestAttachment(canvasPoint);
@@ -472,4 +471,3 @@ namespace WindBoard
         }
     }
 }
-

--- a/MainWindow/MainWindow.InputPipeline.cs
+++ b/MainWindow/MainWindow.InputPipeline.cs
@@ -31,7 +31,7 @@ namespace WindBoard
                 return;
             }
 
-            if (Keyboard.IsKeyDown(Key.Space) && e.ChangedButton == MouseButton.Left)
+            if (e.ChangedButton == MouseButton.Right)
             {
                 _modeBeforePan = _modeController.ActiveMode ?? _modeController.CurrentMode;
                 _zoomPanService.BeginMousePan(e.GetPosition(Viewport));
@@ -68,7 +68,7 @@ namespace WindBoard
 
         private void MyCanvas_MouseUp(object sender, MouseButtonEventArgs e)
         {
-            if (_zoomPanService.IsMousePanning && e.ChangedButton == MouseButton.Left)
+            if (_zoomPanService.IsMousePanning && e.ChangedButton == MouseButton.Right)
             {
                 _zoomPanService.EndMousePan();
                 MyCanvas.ReleaseMouseCapture();

--- a/MainWindow/MainWindow.SettingsSync.cs
+++ b/MainWindow/MainWindow.SettingsSync.cs
@@ -28,6 +28,11 @@ namespace WindBoard
             IsVideoPresenterEnabled = SettingsService.Instance.GetVideoPresenterEnabled();
             ApplyCamouflageFromSettings();
 
+            if (_zoomPanService != null)
+            {
+                try { _zoomPanService.TwoFingerOnly = SettingsService.Instance.GetZoomPanTwoFingerOnly(); } catch { }
+            }
+
             if (_strokeService != null && _zoomPanService != null)
             {
                 _strokeService.SetStrokeThicknessConsistencyEnabled(

--- a/MainWindow/MainWindow.SettingsSync.cs
+++ b/MainWindow/MainWindow.SettingsSync.cs
@@ -27,11 +27,7 @@ namespace WindBoard
             SetBackgroundColor(SettingsService.Instance.GetBackgroundColor());
             IsVideoPresenterEnabled = SettingsService.Instance.GetVideoPresenterEnabled();
             ApplyCamouflageFromSettings();
-
-            if (_zoomPanService != null)
-            {
-                try { _zoomPanService.TwoFingerOnly = SettingsService.Instance.GetZoomPanTwoFingerOnly(); } catch { }
-            }
+            ApplyZoomPanGestureSettingsSnapshot();
 
             if (_strokeService != null && _zoomPanService != null)
             {
@@ -42,6 +38,12 @@ namespace WindBoard
             }
 
             ApplyInkModeSettingsSnapshot();
+        }
+
+        private void ApplyZoomPanGestureSettingsSnapshot()
+        {
+            if (_zoomPanService == null) return;
+            try { _zoomPanService.TwoFingerOnly = SettingsService.Instance.GetZoomPanTwoFingerOnly(); } catch { }
         }
 
         private void ApplyInkModeSettingsSnapshot()

--- a/Models/AppSettings.cs
+++ b/Models/AppSettings.cs
@@ -32,5 +32,8 @@ namespace WindBoard.Models
 
         // 模拟压感（签字笔风格）：用于无压感设备的轻微笔锋效果
         public bool SimulatedPressureEnabled { get; set; } = false;
+
+        // 触摸缩放/平移：仅双指手势（开启后，三指及以上不参与缩放/平移）
+        public bool ZoomPanTwoFingerOnly { get; set; } = false;
     }
 }

--- a/Services/Settings/SettingsService.cs
+++ b/Services/Settings/SettingsService.cs
@@ -172,5 +172,15 @@ namespace WindBoard.Services
             Save();
             SettingsChanged?.Invoke(this, Settings);
         }
+
+        // --- 触摸手势相关设置 ---
+        public bool GetZoomPanTwoFingerOnly() => Settings.ZoomPanTwoFingerOnly;
+
+        public void SetZoomPanTwoFingerOnly(bool enabled)
+        {
+            Settings.ZoomPanTwoFingerOnly = enabled;
+            Save();
+            SettingsChanged?.Invoke(this, Settings);
+        }
     }
 }

--- a/Services/ZoomPanService.cs
+++ b/Services/ZoomPanService.cs
@@ -25,6 +25,8 @@ namespace WindBoard.Services
         public double PanX { get; private set; }
         public double PanY { get; private set; }
 
+        public bool TwoFingerOnly { get; set; }
+
         public bool IsMousePanning => _isMousePanning;
         public bool IsGestureActive => _gestureActive;
 
@@ -131,6 +133,7 @@ namespace WindBoard.Services
             _activeTouches[id] = viewportPoint;
 
             if (!_gestureActive || _activeTouches.Count < 2) return false;
+            if (TwoFingerOnly && _activeTouches.Count != 2) return false;
 
             Point newCenter = GetCentroid();
             double newSpread = GetAverageSpread(newCenter);

--- a/Services/ZoomPanService.cs
+++ b/Services/ZoomPanService.cs
@@ -133,7 +133,7 @@ namespace WindBoard.Services
             _activeTouches[id] = viewportPoint;
 
             if (!_gestureActive || _activeTouches.Count < 2) return false;
-            if (TwoFingerOnly && _activeTouches.Count != 2) return false;
+            if (TwoFingerOnly && _activeTouches.Count > 2) return false;
 
             Point newCenter = GetCentroid();
             double newSpread = GetAverageSpread(newCenter);

--- a/Views/SettingsWindow.Fields.cs
+++ b/Views/SettingsWindow.Fields.cs
@@ -27,6 +27,9 @@ namespace WindBoard
         private bool _strokeThicknessConsistencyEnabled;
         private bool _simulatedPressureEnabled;
 
+        // --- 触摸手势设置 ---
+        private bool _zoomPanTwoFingerOnly;
+
         private const string DefaultVideoPresenterPath = @"C:\\Program Files (x86)\\Seewo\\EasiCamera\\sweclauncher\\sweclauncher.exe";
         private const string DefaultVideoPresenterArgs = "-from en5";
 

--- a/Views/SettingsWindow.TouchGestures.cs
+++ b/Views/SettingsWindow.TouchGestures.cs
@@ -1,0 +1,33 @@
+using System.Windows;
+using WindBoard.Services;
+
+namespace WindBoard
+{
+    public partial class SettingsWindow
+    {
+        public bool ZoomPanTwoFingerOnly
+        {
+            get => _zoomPanTwoFingerOnly;
+            set
+            {
+                if (_zoomPanTwoFingerOnly != value)
+                {
+                    _zoomPanTwoFingerOnly = value;
+                    OnPropertyChanged();
+                    try { SettingsService.Instance.SetZoomPanTwoFingerOnly(value); } catch { }
+                }
+            }
+        }
+
+        private void ToggleZoomPanTwoFingerOnly_Checked(object sender, RoutedEventArgs e)
+        {
+            ZoomPanTwoFingerOnly = true;
+        }
+
+        private void ToggleZoomPanTwoFingerOnly_Unchecked(object sender, RoutedEventArgs e)
+        {
+            ZoomPanTwoFingerOnly = false;
+        }
+    }
+}
+

--- a/Views/SettingsWindow.xaml
+++ b/Views/SettingsWindow.xaml
@@ -247,6 +247,32 @@
                                 </Grid>
                             </Grid>
                         </materialDesign:Card>
+
+                        <!-- 基本设置 · 触摸手势 -->
+                        <materialDesign:Card Padding="20" Margin="0,0,0,20" UniformCornerRadius="12" materialDesign:ElevationAssist.Elevation="Dp2">
+                            <Grid>
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="Auto"/>
+                                    <ColumnDefinition Width="*"/>
+                                    <ColumnDefinition Width="Auto"/>
+                                </Grid.ColumnDefinitions>
+
+                                <Border Width="48" Height="48" CornerRadius="8" Background="{DynamicResource PrimaryHueLightBrush}" Grid.Column="0" VerticalAlignment="Center">
+                                    <materialDesign:PackIcon Kind="CogOutline" Width="24" Height="24" VerticalAlignment="Center" HorizontalAlignment="Center" Foreground="{DynamicResource PrimaryHueMidBrush}"/>
+                                </Border>
+
+                                <StackPanel Grid.Column="1" VerticalAlignment="Center" Margin="16,0,0,0">
+                                    <TextBlock Text="触摸手势" Style="{StaticResource MaterialDesignSubtitle1TextBlock}" FontWeight="SemiBold"/>
+                                    <TextBlock Text="缩放/平移仅在双指触摸时触发" Style="{StaticResource MaterialDesignBodyMediumTextBlock}" Opacity="0.6" TextWrapping="Wrap"/>
+                                </StackPanel>
+
+                                <CheckBox Grid.Column="2" VerticalAlignment="Center"
+                                          Content="仅双指"
+                                          IsChecked="{Binding ElementName=SettingsWindowRoot, Path=ZoomPanTwoFingerOnly, Mode=TwoWay}"
+                                          Checked="ToggleZoomPanTwoFingerOnly_Checked"
+                                          Unchecked="ToggleZoomPanTwoFingerOnly_Unchecked"/>
+                            </Grid>
+                        </materialDesign:Card>
                     </StackPanel>
 
                     <!-- 书写设置 面板（索引 1） -->

--- a/Views/SettingsWindow.xaml.cs
+++ b/Views/SettingsWindow.xaml.cs
@@ -97,7 +97,6 @@ namespace WindBoard
             try { SettingsService.Instance.SetCamouflageSourcePath(CamouflageSourcePath); } catch { }
             try { SettingsService.Instance.SetStrokeThicknessConsistencyEnabled(StrokeThicknessConsistencyEnabled); } catch { }
             try { SettingsService.Instance.SetSimulatedPressureEnabled(SimulatedPressureEnabled); } catch { }
-            try { SettingsService.Instance.SetZoomPanTwoFingerOnly(ZoomPanTwoFingerOnly); } catch { }
         }
 
         private void BtnApply_Click(object sender, RoutedEventArgs e) => ApplyAllSettings();

--- a/Views/SettingsWindow.xaml.cs
+++ b/Views/SettingsWindow.xaml.cs
@@ -52,6 +52,17 @@ namespace WindBoard
             OnPropertyChanged(nameof(StrokeThicknessConsistencyEnabled));
             OnPropertyChanged(nameof(SimulatedPressureEnabled));
 
+            // 初始化“触摸手势”
+            try
+            {
+                _zoomPanTwoFingerOnly = SettingsService.Instance.GetZoomPanTwoFingerOnly();
+            }
+            catch
+            {
+                _zoomPanTwoFingerOnly = false;
+            }
+            OnPropertyChanged(nameof(ZoomPanTwoFingerOnly));
+
             // 初始化伪装相关设置
             try
             {
@@ -86,6 +97,7 @@ namespace WindBoard
             try { SettingsService.Instance.SetCamouflageSourcePath(CamouflageSourcePath); } catch { }
             try { SettingsService.Instance.SetStrokeThicknessConsistencyEnabled(StrokeThicknessConsistencyEnabled); } catch { }
             try { SettingsService.Instance.SetSimulatedPressureEnabled(SimulatedPressureEnabled); } catch { }
+            try { SettingsService.Instance.SetZoomPanTwoFingerOnly(ZoomPanTwoFingerOnly); } catch { }
         }
 
         private void BtnApply_Click(object sender, RoutedEventArgs e) => ApplyAllSettings();

--- a/WindBoard.Tests/Services/ZoomPanServiceTests.cs
+++ b/WindBoard.Tests/Services/ZoomPanServiceTests.cs
@@ -67,5 +67,30 @@ public sealed class ZoomPanServiceTests
         Assert.True(svc.TouchMove(2, new Point(200, 0)));
         Assert.True(svc.Zoom > 1.0);
     }
-}
 
+    [StaFact]
+    public void TouchGesture_TwoFingerOnly_ThreeTouches_DoesNotUpdateZoom()
+    {
+        var zoomTransform = new ScaleTransform(1, 1);
+        var panTransform = new TranslateTransform(0, 0);
+        var svc = new ZoomPanService(zoomTransform, panTransform, minZoom: 0.5, maxZoom: 5.0)
+        {
+            TwoFingerOnly = true
+        };
+
+        Assert.False(svc.TouchDown(1, new Point(0, 0)));
+        Assert.True(svc.TouchDown(2, new Point(100, 0)));
+        Assert.True(svc.TouchDown(3, new Point(200, 0)));
+        Assert.True(svc.IsGestureActive);
+
+        double zoomBefore = svc.Zoom;
+        Assert.False(svc.TouchMove(2, new Point(150, 0)));
+        Assert.Equal(zoomBefore, svc.Zoom, precision: 12);
+
+        svc.TouchUp(3);
+        Assert.True(svc.IsGestureActive);
+
+        Assert.True(svc.TouchMove(2, new Point(200, 0)));
+        Assert.True(svc.Zoom > zoomBefore);
+    }
+}


### PR DESCRIPTION
## Summary by Sourcery

添加可配置的仅双指触控缩放/平移行为，并将鼠标平移从 `space+左键拖拽` 改为使用鼠标右键。

新功能：
- 引入一个用户设置，用于将触控缩放/平移手势限制为严格的双指操作，该设置会持久保存到应用程序设置中，并可在设置窗口中进行配置。

错误修复：
- 在启用“仅双指模式”时，当超过两根手指参与操作时，阻止触控缩放更新，并通过测试覆盖该行为。

增强改进：
- 在启动时以及设置更改时，用新的“仅双指”设置初始化并同步 `ZoomPanService`。
- 更新选择交互逻辑，使其不再依赖空格键，以与新的平移交互模型保持一致。
- 明确文档说明 `ZoomPanService` 中使用鼠标右键拖拽进行平移的行为。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add configurable two-finger-only touch zoom/pan behavior and switch mouse panning to use the right button instead of space+left drag.

New Features:
- Introduce a user setting to restrict touch zoom/pan gestures to exactly two fingers, persisted in application settings and configurable from the settings window.

Bug Fixes:
- Prevent touch zoom updates when more than two fingers are involved while two-finger-only mode is enabled, with tests covering the behavior.

Enhancements:
- Initialize and synchronize the ZoomPanService with the new two-finger-only setting at startup and when settings change.
- Update selection interaction to no longer depend on the space key, aligning with the new panning interaction model.
- Clarify documentation to describe right-button drag panning in ZoomPanService.

</details>