### PR TITLE
fix(installer): 修复ISS脚本中的条件判断语法

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -112,8 +112,8 @@ jobs:
 
             & $iscc `
               "/DMyAppVersion=$version" `
-              "/DMySourceDir=$publishDirSc" `
-              "/DMyOutputDir=$dist" `
+              ("/DMySourceDir={0}" -f ('"' + $publishDirSc + '"')) `
+              ("/DMyOutputDir={0}" -f ('"' + $dist + '"')) `
               "/DMyArch=$arch" `
               "/DMyRid=$rid" `
               $issPath

--- a/installer/WindBoard.iss
+++ b/installer/WindBoard.iss
@@ -10,19 +10,19 @@
 ;   MyArch        ("x86" | "x64" | "arm64")
 ;   MyRid         ("win-x86" | "win-x64" | "win-arm64")
 
-#ifnexist MyAppVersion
+#ifndef MyAppVersion
   #error MyAppVersion is required
 #endif
-#ifnexist MySourceDir
+#ifndef MySourceDir
   #error MySourceDir is required
 #endif
-#ifnexist MyOutputDir
+#ifndef MyOutputDir
   #error MyOutputDir is required
 #endif
-#ifnexist MyArch
+#ifndef MyArch
   #error MyArch is required
 #endif
-#ifnexist MyRid
+#ifndef MyRid
   #error MyRid is required
 #endif
 


### PR DESCRIPTION
将`#ifnexist`改为`#ifndef`以符合Inno Setup的正确语法，并调整参数传递中的引号处理

## Summary by Sourcery

确保 Inno Setup 安装程序脚本使用正确的预处理器条件语法，并修复发布工作流中目录参数的传递方式，以正确处理引号问题。

错误修复：
- 更正 Inno Setup 脚本中对必需定义项的预处理器检查，使其使用受支持的条件语法。
- 调整发布工作流，在传递源目录和输出目录路径给 Inno Setup 编译器时使用适当的引号，从而安全地传递这些路径。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Ensure the Inno Setup installer script uses correct preprocessor condition syntax and fix passing of directory arguments in the release workflow to handle quoting correctly.

Bug Fixes:
- Correct the Inno Setup script preprocessor checks for required defines to use the supported conditional syntax.
- Adjust the release workflow to safely pass source and output directory paths with proper quoting to the Inno Setup compiler.

</details>