### PR TITLE
ci(workflow): 修复发布工作流中路径拼接问题

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -95,6 +95,8 @@ jobs:
             $arch = $v.Arch
             $publishDirSc = Join-Path $PWD ("publish/{0}/sc" -f $rid)
             $issPath = Join-Path $PWD 'installer/WindBoard.iss'
+            $publishDirScForIss = Join-Path '..' ("publish\\{0}\\sc" -f $rid)
+            $distForIss = Join-Path '..' 'dist'
 
             $setupFileName = "WindBoardSetup-$version-$rid.exe"
             $setupPath = Join-Path $dist $setupFileName
@@ -112,8 +114,8 @@ jobs:
 
             & $iscc `
               "/DMyAppVersion=$version" `
-              ("/DMySourceDir={0}" -f ('"' + $publishDirSc + '"')) `
-              ("/DMyOutputDir={0}" -f ('"' + $dist + '"')) `
+              "/DMySourceDir=$publishDirScForIss" `
+              "/DMyOutputDir=$distForIss" `
               "/DMyArch=$arch" `
               "/DMyRid=$rid" `
               $issPath


### PR DESCRIPTION
修复 Inno Setup 编译器中路径拼接错误，使用相对路径替代绝对路径以避免潜在问题

## Summary by Sourcery

CI：
- 调整发布工作流，将相对的 `publish` 和 `dist` 路径传递给 Inno Setup 编译器，而不是传递绝对路径，以避免路径拼接问题。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

CI:
- Adjust the release workflow to pass relative publish and dist paths into the Inno Setup compiler instead of absolute paths to avoid path concatenation issues.

</details>