### PR TITLE
fix(installer): 修复中文语言文件路径检查问题

### DIFF
--- a/installer/WindBoard.iss
+++ b/installer/WindBoard.iss
@@ -66,7 +66,9 @@ ArchitecturesInstallIn64BitMode={#MyArchitecturesInstallIn64BitMode}
 
 [Languages]
 Name: "english"; MessagesFile: "compiler:Default.isl"
-Name: "chs"; MessagesFile: "compiler:Languages\\ChineseSimplified.isl"
+#ifexist "compiler:Languages\\Unofficial\\ChineseSimplified.isl"
+Name: "chs"; MessagesFile: "compiler:Languages\\Unofficial\\ChineseSimplified.isl"
+#endif
 
 [Files]
 Source: "{#MySourceDir}\*"; DestDir: "{app}"; Flags: ignoreversion recursesubdirs createallsubdirs

--- a/installer/WindBoard.iss
+++ b/installer/WindBoard.iss
@@ -68,6 +68,10 @@ ArchitecturesInstallIn64BitMode={#MyArchitecturesInstallIn64BitMode}
 Name: "english"; MessagesFile: "compiler:Default.isl"
 #ifexist "compiler:Languages\\Unofficial\\ChineseSimplified.isl"
 Name: "chs"; MessagesFile: "compiler:Languages\\Unofficial\\ChineseSimplified.isl"
+#else
+  #ifexist "compiler:Languages\\ChineseSimplified.isl"
+Name: "chs"; MessagesFile: "compiler:Languages\\ChineseSimplified.isl"
+  #endif
 #endif
 
 [Files]


### PR DESCRIPTION
添加对非官方中文语言文件路径的条件检查，防止安装程序在文件不存在时报错
草台班子

## Summary by Sourcery

错误修复：
- 防止在缺少非官方简体中文语言消息文件时安装程序发生失败。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Prevent the installer from failing when the unofficial Simplified Chinese language messages file is missing.

</details>