### PR TITLE
feat(更新): 重构更新功能并移除最低系统版本检查

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -136,9 +136,21 @@ jobs:
             }
           }
 
-          $commitLines = git log -n 30 --pretty=format:"- %s"
-          $changelogEn = "## Changes`n$commitLines"
-          $changelogZh = "## 更新内容`n$commitLines"
+          $prevTag = $null
+          try { $prevTag = (git describe --tags --abbrev=0 --match "v*" "$tag^" 2>$null).Trim() } catch { }
+
+          if (![string]::IsNullOrWhiteSpace($prevTag)) {
+            $commitLines = (git log "$prevTag..$tag" --pretty=format:"- %s") -join "`n"
+            $rangeLabelEn = "$prevTag..$tag"
+            $rangeLabelZh = "$prevTag..$tag"
+          } else {
+            $commitLines = (git log -n 30 --pretty=format:"- %s") -join "`n"
+            $rangeLabelEn = "latest 30 commits"
+            $rangeLabelZh = "最近 30 条提交"
+          }
+
+          $changelogEn = "## Changes ($rangeLabelEn)`n$commitLines"
+          $changelogZh = "## 更新内容（$rangeLabelZh）`n$commitLines"
 
           $releaseDate = (Get-Date).ToUniversalTime().ToString('yyyy-MM-ddTHH:mm:ssZ')
 
@@ -146,7 +158,6 @@ jobs:
             version = $version
             versionName = $tag
             releaseDate = $releaseDate
-            minSystemVersion = '10.0.26100.0'
             changelog = @{
               'zh-CN' = $changelogZh
               'en-US' = $changelogEn
@@ -157,6 +168,16 @@ jobs:
           $latestJsonPath = Join-Path $dist 'latest.json'
           ($latest | ConvertTo-Json -Depth 10) | Set-Content -Path $latestJsonPath -Encoding UTF8
 
+          $releaseNotes = @"
+          $changelogZh
+
+          ---
+
+          $changelogEn
+          "@
+          $releaseNotesPath = Join-Path $dist 'release-notes.md'
+          $releaseNotes.Trim() | Set-Content -Path $releaseNotesPath -Encoding UTF8
+
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:
@@ -164,4 +185,5 @@ jobs:
             dist/*.zip
             dist/*.exe
             dist/latest.json
-          generate_release_notes: true
+          body_path: dist/release-notes.md
+          generate_release_notes: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -168,13 +168,13 @@ jobs:
           $latestJsonPath = Join-Path $dist 'latest.json'
           ($latest | ConvertTo-Json -Depth 10) | Set-Content -Path $latestJsonPath -Encoding UTF8
 
-          $releaseNotes = @"
-          $changelogZh
-
-          ---
-
-          $changelogEn
-          "@
+          $releaseNotes = @(
+            $changelogZh
+            ''
+            '---'
+            ''
+            $changelogEn
+          ) -join "`n"
           $releaseNotesPath = Join-Path $dist 'release-notes.md'
           $releaseNotes.Trim() | Set-Content -Path $releaseNotesPath -Encoding UTF8
 

--- a/Models/Update/UpdateInfo.cs
+++ b/Models/Update/UpdateInfo.cs
@@ -15,9 +15,6 @@ namespace WindBoard.Models.Update
         [JsonProperty("releaseDate")]
         public DateTime ReleaseDate { get; set; }
 
-        [JsonProperty("minSystemVersion")]
-        public string MinSystemVersion { get; set; } = string.Empty;
-
         [JsonProperty("changelog")]
         public Dictionary<string, string> Changelog { get; set; } = new(StringComparer.OrdinalIgnoreCase);
 
@@ -25,4 +22,3 @@ namespace WindBoard.Models.Update
         public List<UpdateAsset> Assets { get; set; } = new();
     }
 }
-

--- a/Resources/Strings.en-US.xaml
+++ b/Resources/Strings.en-US.xaml
@@ -271,7 +271,6 @@
     <sys:String x:Key="UpdateWindow_Info_CurrentVersion">Current</sys:String>
     <sys:String x:Key="UpdateWindow_Info_LatestVersion">Latest</sys:String>
     <sys:String x:Key="UpdateWindow_Info_ReleaseDate">Released</sys:String>
-    <sys:String x:Key="UpdateWindow_Info_MinSystemVersion">Min OS</sys:String>
 
     <sys:String x:Key="UpdateWindow_Download_Title">Download</sys:String>
     <sys:String x:Key="UpdateWindow_Download_AssetLabel">Package</sys:String>

--- a/Resources/Strings.zh-CN.xaml
+++ b/Resources/Strings.zh-CN.xaml
@@ -271,7 +271,6 @@
     <sys:String x:Key="UpdateWindow_Info_CurrentVersion">当前版本</sys:String>
     <sys:String x:Key="UpdateWindow_Info_LatestVersion">最新版本</sys:String>
     <sys:String x:Key="UpdateWindow_Info_ReleaseDate">发布日期</sys:String>
-    <sys:String x:Key="UpdateWindow_Info_MinSystemVersion">最低系统版本</sys:String>
 
     <sys:String x:Key="UpdateWindow_Download_Title">下载</sys:String>
     <sys:String x:Key="UpdateWindow_Download_AssetLabel">将下载</sys:String>

--- a/Services/UpdateService.cs
+++ b/Services/UpdateService.cs
@@ -115,21 +115,6 @@ namespace WindBoard.Services
                 return result;
             }
 
-            if (!string.IsNullOrWhiteSpace(updateInfo.MinSystemVersion))
-            {
-                System.Version? minSystemVersion = TryParseStableVersion(updateInfo.MinSystemVersion);
-                if (minSystemVersion != null)
-                {
-                    System.Version currentSystemVersion = Environment.OSVersion.Version;
-                    if (currentSystemVersion < minSystemVersion)
-                    {
-                        result.UpdateAvailable = false;
-                        result.ErrorMessage = $"Requires Windows {minSystemVersion} or later.";
-                        return result;
-                    }
-                }
-            }
-
             if (!string.IsNullOrWhiteSpace(skippedVersion))
             {
                 System.Version? skippedParsed = TryParseStableVersion(skippedVersion);

--- a/ViewModels/UpdateViewModel.cs
+++ b/ViewModels/UpdateViewModel.cs
@@ -4,8 +4,12 @@ using System.Diagnostics;
 using System.Globalization;
 using System.IO;
 using System.Runtime.CompilerServices;
+using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Documents;
+using Markdig;
 using WindBoard.Models;
 using WindBoard.Models.Update;
 using WindBoard.Services;
@@ -27,8 +31,9 @@ namespace WindBoard.ViewModels
         private string _statusText = string.Empty;
         private string _latestVersion = "-";
         private string _releaseDate = "-";
-        private string _minSystemVersion = "-";
         private string _changelogText = string.Empty;
+        private FlowDocument _changelogDocument = new();
+        private bool _isUpdateAvailable;
 
         private bool _isChecking;
         private bool _isDownloading;
@@ -82,16 +87,32 @@ namespace WindBoard.ViewModels
             private set => SetField(ref _releaseDate, value);
         }
 
-        public string MinSystemVersion
-        {
-            get => _minSystemVersion;
-            private set => SetField(ref _minSystemVersion, value);
-        }
-
         public string ChangelogText
         {
             get => _changelogText;
-            private set => SetField(ref _changelogText, value);
+            private set
+            {
+                if (Equals(_changelogText, value))
+                {
+                    return;
+                }
+
+                _changelogText = value;
+                OnPropertyChanged();
+                UpdateChangelogDocument();
+            }
+        }
+
+        public FlowDocument ChangelogDocument
+        {
+            get => _changelogDocument;
+            private set => SetField(ref _changelogDocument, value);
+        }
+
+        public bool IsUpdateAvailable
+        {
+            get => _isUpdateAvailable;
+            private set => SetField(ref _isUpdateAvailable, value);
         }
 
         public string SelectedAssetDisplay => _selectedAsset?.FileName ?? "-";
@@ -134,13 +155,13 @@ namespace WindBoard.ViewModels
             private set => SetField(ref _downloadProgressText, value);
         }
 
-        public bool CanDownload => !_isChecking && !_isDownloading && _selectedAsset != null;
+        public bool CanDownload => IsUpdateAvailable && !_isChecking && !_isDownloading && _selectedAsset != null;
 
-        public bool CanSkipVersion => !_isChecking && !_isDownloading && _updateInfo != null;
+        public bool CanSkipVersion => IsUpdateAvailable && !_isChecking && !_isDownloading && _updateInfo != null;
 
-        public bool CanOpenDownloadedFolder => !_isChecking && !_isDownloading && !string.IsNullOrWhiteSpace(_downloadedPath);
+        public bool CanOpenDownloadedFolder => IsUpdateAvailable && !_isChecking && !_isDownloading && !string.IsNullOrWhiteSpace(_downloadedPath);
 
-        public bool CanInstallDownloaded => !_isChecking && !_isDownloading && _selectedAsset != null && UpdateService.IsInstallerAsset(_selectedAsset) && !string.IsNullOrWhiteSpace(_downloadedPath);
+        public bool CanInstallDownloaded => IsUpdateAvailable && !_isChecking && !_isDownloading && _selectedAsset != null && UpdateService.IsInstallerAsset(_selectedAsset) && !string.IsNullOrWhiteSpace(_downloadedPath);
 
         public async Task InitializeAsync()
         {
@@ -182,6 +203,7 @@ namespace WindBoard.ViewModels
             }
 
             _updateInfo = result.LatestVersion;
+            IsUpdateAvailable = result.UpdateAvailable;
             _installEnvironment = InstallModeDetector.Detect();
             OnPropertyChanged(nameof(InstallMethodHint));
 
@@ -189,7 +211,6 @@ namespace WindBoard.ViewModels
             ReleaseDate = _updateInfo.ReleaseDate != default
                 ? _updateInfo.ReleaseDate.ToLocalTime().ToString("yyyy-MM-dd HH:mm", CultureInfo.CurrentUICulture)
                 : "-";
-            MinSystemVersion = string.IsNullOrWhiteSpace(_updateInfo.MinSystemVersion) ? "-" : _updateInfo.MinSystemVersion;
             ChangelogText = ResolveLocalizedChangelog(_updateInfo);
 
             _selectedAsset = _updateService.SelectAssetForCurrentInstallation(_updateInfo, _installEnvironment);
@@ -325,7 +346,7 @@ namespace WindBoard.ViewModels
 
         public void SkipThisVersion()
         {
-            if (_updateInfo == null)
+            if (_updateInfo == null || !IsUpdateAvailable)
             {
                 return;
             }
@@ -347,17 +368,104 @@ namespace WindBoard.ViewModels
             _installEnvironment = null;
             _selectedAsset = null;
             _downloadedPath = null;
+            IsUpdateAvailable = false;
 
             DownloadProgressVisible = false;
             DownloadProgressPercent = 0;
             DownloadProgressText = string.Empty;
             LatestVersion = "-";
             ReleaseDate = "-";
-            MinSystemVersion = "-";
             ChangelogText = string.Empty;
 
             OnPropertyChanged(nameof(SelectedAssetDisplay));
             OnPropertyChanged(nameof(InstallMethodHint));
+        }
+
+        private static readonly MarkdownPipeline _markdownPipeline = new MarkdownPipelineBuilder()
+            .UseAdvancedExtensions()
+            .UseSoftlineBreakAsHardlineBreak()
+            .Build();
+
+        private void UpdateChangelogDocument()
+        {
+            string markdown = NormalizeChangelogMarkdown(_changelogText ?? string.Empty);
+
+            FlowDocument document;
+            try
+            {
+                document = Markdig.Wpf.Markdown.ToFlowDocument(markdown, _markdownPipeline);
+            }
+            catch (Exception ex)
+            {
+                Debug.WriteLine($"[Update] Failed to render changelog markdown: {ex}");
+                document = new FlowDocument();
+                document.Blocks.Add(new Paragraph(new Run(markdown)));
+            }
+
+            if (Application.Current?.TryFindResource("AppFontFamily") is System.Windows.Media.FontFamily appFontFamily)
+            {
+                document.FontFamily = appFontFamily;
+            }
+
+            document.PagePadding = new Thickness(0);
+            ChangelogDocument = document;
+        }
+
+        private static string NormalizeChangelogMarkdown(string markdown)
+        {
+            if (string.IsNullOrWhiteSpace(markdown))
+            {
+                return string.Empty;
+            }
+
+            string normalized = markdown.Replace("\r\n", "\n").Replace('\r', '\n');
+
+            // Compatibility: older release workflow embedded a string[] (git log output) into an interpolated string,
+            // which PowerShell joins with spaces, collapsing Markdown list items into a single line.
+            int firstBullet = normalized.IndexOf("\n- ", StringComparison.Ordinal);
+            if (firstBullet < 0)
+            {
+                return normalized;
+            }
+
+            string listPart = normalized[(firstBullet + 1)..];
+            if (CountOccurrences(listPart, "\n- ") > 1)
+            {
+                return normalized;
+            }
+
+            const string prefixes = "feat|fix|docs|refactor|perf|chore|build|ci|test|style|Merge";
+            string pattern = $@"\s-\s(?=(?:{prefixes})(?:\(|:|\s))";
+
+            if (!Regex.IsMatch(listPart, pattern, RegexOptions.IgnoreCase | RegexOptions.CultureInvariant))
+            {
+                return normalized;
+            }
+
+            string fixedList = Regex.Replace(listPart, pattern, "\n- ", RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
+            return normalized[..(firstBullet + 1)] + fixedList;
+        }
+
+        private static int CountOccurrences(string text, string token)
+        {
+            if (string.IsNullOrEmpty(text) || string.IsNullOrEmpty(token))
+            {
+                return 0;
+            }
+
+            int count = 0;
+            int index = 0;
+            while (true)
+            {
+                int next = text.IndexOf(token, index, StringComparison.Ordinal);
+                if (next < 0)
+                {
+                    return count;
+                }
+
+                count++;
+                index = next + token.Length;
+            }
         }
 
         private string ResolveLocalizedChangelog(UpdateInfo updateInfo)
@@ -426,4 +534,3 @@ namespace WindBoard.ViewModels
         }
     }
 }
-

--- a/ViewModels/UpdateViewModel.cs
+++ b/ViewModels/UpdateViewModel.cs
@@ -112,7 +112,17 @@ namespace WindBoard.ViewModels
         public bool IsUpdateAvailable
         {
             get => _isUpdateAvailable;
-            private set => SetField(ref _isUpdateAvailable, value);
+            private set
+            {
+                if (Equals(_isUpdateAvailable, value))
+                {
+                    return;
+                }
+
+                _isUpdateAvailable = value;
+                OnPropertyChanged();
+                NotifyComputed();
+            }
         }
 
         public string SelectedAssetDisplay => _selectedAsset?.FileName ?? "-";

--- a/Views/UpdateWindow.xaml
+++ b/Views/UpdateWindow.xaml
@@ -55,7 +55,6 @@
                                 <RowDefinition Height="Auto"/>
                                 <RowDefinition Height="Auto"/>
                                 <RowDefinition Height="Auto"/>
-                                <RowDefinition Height="Auto"/>
                             </Grid.RowDefinitions>
                             <Grid.ColumnDefinitions>
                                 <ColumnDefinition Width="Auto"/>
@@ -70,9 +69,6 @@
 
                             <TextBlock Grid.Row="2" Grid.Column="0" Margin="0,0,12,8" Opacity="0.75" Text="{DynamicResource UpdateWindow_Info_ReleaseDate}"/>
                             <TextBlock Grid.Row="2" Grid.Column="1" Margin="0,0,0,8" Text="{Binding ReleaseDate}" TextTrimming="CharacterEllipsis"/>
-
-                            <TextBlock Grid.Row="3" Grid.Column="0" Margin="0,0,12,0" Opacity="0.75" Text="{DynamicResource UpdateWindow_Info_MinSystemVersion}"/>
-                            <TextBlock Grid.Row="3" Grid.Column="1" Margin="0,0,0,0" Text="{Binding MinSystemVersion}" TextTrimming="CharacterEllipsis"/>
                         </Grid>
 
                         <TextBlock Margin="0,14,0,0"
@@ -82,7 +78,11 @@
                         </StackPanel>
                     </materialDesign:Card>
 
-                    <materialDesign:Card Padding="18" UniformCornerRadius="12" materialDesign:ElevationAssist.Elevation="Dp2" Margin="0,16,0,0">
+                    <materialDesign:Card Padding="18"
+                                        UniformCornerRadius="12"
+                                        materialDesign:ElevationAssist.Elevation="Dp2"
+                                        Margin="0,16,0,0"
+                                        Visibility="{Binding IsUpdateAvailable, Converter={StaticResource BoolToVis}}">
                         <StackPanel>
                         <TextBlock Text="{DynamicResource UpdateWindow_Download_Title}"
                                    Style="{StaticResource MaterialDesignSubtitle1TextBlock}"
@@ -165,13 +165,13 @@
                                Style="{StaticResource MaterialDesignSubtitle1TextBlock}"
                                FontWeight="SemiBold"
                                Margin="0,0,0,12"/>
-                    <TextBox Text="{Binding ChangelogText, Mode=OneWay}"
-                             IsReadOnly="True"
-                             TextWrapping="Wrap"
-                             VerticalScrollBarVisibility="Auto"
-                             HorizontalScrollBarVisibility="Auto"
-                             Background="{DynamicResource MaterialDesignCardBackground}"
-                             BorderThickness="0"/>
+                    <FlowDocumentScrollViewer Document="{Binding ChangelogDocument}"
+                                              VerticalScrollBarVisibility="Auto"
+                                              HorizontalScrollBarVisibility="Disabled"
+                                              Background="{DynamicResource MaterialDesignCardBackground}"
+                                              BorderThickness="0"
+                                              Padding="0"
+                                              Focusable="False"/>
                 </DockPanel>
             </materialDesign:Card>
         </Grid>
@@ -192,6 +192,7 @@
                             Margin="0,0,8,0"
                             Click="BtnSkipVersion_Click"
                             IsEnabled="{Binding CanSkipVersion}"
+                            Visibility="{Binding IsUpdateAvailable, Converter={StaticResource BoolToVis}}"
                             materialDesign:ButtonAssist.CornerRadius="6">
                         <TextBlock Text="{DynamicResource UpdateWindow_SkipVersion_Button}"/>
                     </Button>

--- a/Views/UpdateWindow.xaml.cs
+++ b/Views/UpdateWindow.xaml.cs
@@ -46,9 +46,28 @@ namespace WindBoard
                 return;
             }
 
+            if (!e.Uri.IsAbsoluteUri)
+            {
+                Debug.WriteLine($"[UpdateWindow] Ignored non-absolute URI: {e.Uri}");
+                e.Handled = true;
+                return;
+            }
+
+            string scheme = e.Uri.Scheme;
+            bool allowed = string.Equals(scheme, Uri.UriSchemeHttp, StringComparison.OrdinalIgnoreCase)
+                || string.Equals(scheme, Uri.UriSchemeHttps, StringComparison.OrdinalIgnoreCase)
+                || string.Equals(scheme, "mailto", StringComparison.OrdinalIgnoreCase);
+
+            if (!allowed)
+            {
+                Debug.WriteLine($"[UpdateWindow] Ignored unsupported URI scheme: {scheme} ({e.Uri})");
+                e.Handled = true;
+                return;
+            }
+
             try
             {
-                Process.Start(new ProcessStartInfo(e.Uri.AbsoluteUri)
+                Process.Start(new ProcessStartInfo(e.Uri.ToString())
                 {
                     UseShellExecute = true
                 });

--- a/Views/UpdateWindow.xaml.cs
+++ b/Views/UpdateWindow.xaml.cs
@@ -2,6 +2,8 @@ using System;
 using System.Diagnostics;
 using System.Threading.Tasks;
 using System.Windows;
+using System.Windows.Documents;
+using System.Windows.Navigation;
 using WindBoard.ViewModels;
 
 namespace WindBoard
@@ -17,6 +19,8 @@ namespace WindBoard
             _viewModel = new UpdateViewModel();
             _viewModel.RequestClose += ViewModel_RequestClose;
             DataContext = _viewModel;
+
+            AddHandler(Hyperlink.RequestNavigateEvent, new RequestNavigateEventHandler(ChangelogHyperlink_RequestNavigate));
 
             Loaded += UpdateWindow_Loaded;
             Closed += UpdateWindow_Closed;
@@ -34,6 +38,27 @@ namespace WindBoard
         }
 
         private void ViewModel_RequestClose(object? sender, EventArgs e) => Close();
+
+        private static void ChangelogHyperlink_RequestNavigate(object sender, RequestNavigateEventArgs e)
+        {
+            if (e.Uri == null)
+            {
+                return;
+            }
+
+            try
+            {
+                Process.Start(new ProcessStartInfo(e.Uri.AbsoluteUri)
+                {
+                    UseShellExecute = true
+                });
+                e.Handled = true;
+            }
+            catch (Exception ex)
+            {
+                Debug.WriteLine($"[UpdateWindow] Failed to open link: {ex}");
+            }
+        }
 
         private async void BtnDownload_Click(object sender, RoutedEventArgs e)
         {

--- a/WindBoard.Tests/Services/UpdateServiceTests.cs
+++ b/WindBoard.Tests/Services/UpdateServiceTests.cs
@@ -66,7 +66,6 @@ public sealed class UpdateServiceTests
           "version": "9999.0.0",
           "versionName": "v9999.0.0",
           "releaseDate": "2024-01-15T10:30:00Z",
-          "minSystemVersion": "10.0.0.0",
           "changelog": { "en-US": "Test" },
           "assets": [
             {
@@ -107,7 +106,6 @@ public sealed class UpdateServiceTests
           "version": "9999.0.0",
           "versionName": "v9999.0.0",
           "releaseDate": "2024-01-15T10:30:00Z",
-          "minSystemVersion": "10.0.0.0",
           "changelog": { "en-US": "Test" },
           "assets": []
         }

--- a/WindBoard.csproj
+++ b/WindBoard.csproj
@@ -10,6 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Markdig.Wpf" Version="0.5.0.1" />
     <PackageReference Include="MaterialDesignColors" Version="5.3.0" />
     <PackageReference Include="MaterialDesignThemes" Version="5.3.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />


### PR DESCRIPTION
- 移除最低系统版本检查及相关UI元素
- 添加Markdig.Wpf包支持Markdown渲染
- 改进更新日志显示为富文本格式
- 优化GitHub发布工作流中的更新日志生成
- 添加超链接点击处理功能
- 根据更新可用性动态控制UI元素显示

## Summary by Sourcery

通过移除最低系统版本处理、改进更新日志渲染方式，以及收紧版本发布与更新相关 UI 的生成和展示逻辑，优化更新体验。

新功能：
- 使用 Markdown 将更新日志渲染为富文本 FlowDocument，并在更新窗口中支持超链接。
- 在视图模型中暴露一个明确的“更新可用”标志，用于驱动与更新相关的 UI 状态和操作。

缺陷修复：
- 规范并修复自动生成的更新日志 Markdown，当发布工作流将项目符号列表压缩为单行时，能够正确恢复为列表格式。

增强改进：
- 从更新模型、服务、UI 和生成的元数据中移除最低系统版本字段及其检查逻辑，简化更新资格判定。
- 将下载、跳过此版本、打开文件夹、安装等操作统一以“实际存在可用更新”为前提进行控制，避免在无更新时执行无效操作。
- 调整发布工作流中的更新日志生成逻辑，在可用时使用标签区间生成日志，并将本地化的 Markdown 作为 GitHub Release Notes 嵌入，而不是使用自动生成的说明。

构建：
- 添加 `Markdig.Wpf` 依赖，以支持在更新视图中进行 WPF 的 markdown-to-FlowDocument 渲染。

CI：
- 调整发布相关的 GitHub Actions 工作流，从标签区间计算更新日志条目，生成本地化的 Markdown 发布说明，并将其作为 GitHub Release 的正文，而非使用自动生成的说明。

测试：
- 更新 update-service 相关测试，以反映更新元数据中移除最低系统版本字段的变更。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refine the update experience by removing minimum system version handling, improving changelog rendering, and tightening how releases and update-related UI are generated and presented.

New Features:
- Render update changelogs as rich-text FlowDocuments using Markdown, including hyperlink support in the update window.
- Expose an explicit update-availability flag in the view model to drive update-related UI state and actions.

Bug Fixes:
- Normalize and repair auto-generated changelog markdown to correctly restore bullet lists when the release workflow collapses them into a single line.

Enhancements:
- Drop minimum system version fields and checks from the update model, service, UI, and generated metadata, simplifying update eligibility logic.
- Gate download, skip-version, open-folder, and install actions on actual update availability to avoid invalid operations when no update is present.
- Align changelog generation in the release workflow to use tag ranges when available and embed localized markdown as GitHub release notes instead of auto-generated notes.

Build:
- Add the Markdig.Wpf dependency to support WPF markdown-to-FlowDocument rendering in the update view.

CI:
- Adjust the release GitHub Actions workflow to compute changelog entries from tag ranges, emit localized markdown release notes, and use them as the GitHub release body instead of generated notes.

Tests:
- Update update-service tests to reflect removal of the minimum system version field from update metadata.

</details>