### PR TITLE
更改设置逻辑

### DIFF
--- a/WindBoard.Tests/Persistence/AppDataPathsTests.cs
+++ b/WindBoard.Tests/Persistence/AppDataPathsTests.cs
@@ -1,31 +1,10 @@
-using System;
-using System.Collections.Generic;
-using System.IO;
 using WindBoard.Persistence;
 using WindBoard.Updates;
 
 namespace WindBoard.Tests.Persistence;
 
-public sealed class AppDataPathsTests : IDisposable
+public sealed class AppDataPathsTests
 {
-    private readonly List<string> _tempDirs = new();
-
-    public void Dispose()
-    {
-        foreach (string dir in _tempDirs)
-        {
-            try { if (Directory.Exists(dir)) Directory.Delete(dir, recursive: true); } catch { }
-        }
-    }
-
-    private string CreateTempDir()
-    {
-        string dir = Path.Combine(Path.GetTempPath(), $"WindBoardTests_{Guid.NewGuid():N}");
-        Directory.CreateDirectory(dir);
-        _tempDirs.Add(dir);
-        return dir;
-    }
-
     [Fact]
     public void ComputeSnapshot_Installer_UsesLocalAppData()
     {
@@ -115,41 +94,4 @@ public sealed class AppDataPathsTests : IDisposable
         Assert.False(snapshot.PortableDataDirectoryWritable);
         Assert.Equal("AccessDenied", snapshot.PortableDataDirectoryWriteTestError);
     }
-
-    [Fact]
-    public void TryMigrateSettingsFileIfNeeded_WhenDestinationMissing_CopiesFile()
-    {
-        string root = CreateTempDir();
-        string source = Path.Combine(root, "old", "settings.json");
-        string dest = Path.Combine(root, "data", "settings.json");
-
-        Directory.CreateDirectory(Path.GetDirectoryName(source)!);
-        File.WriteAllText(source, "{\"a\":1}");
-
-        SettingsMigrationResult result = AppDataPaths.TryMigrateSettingsFileIfNeeded(source, dest);
-
-        Assert.True(result.Migrated);
-        Assert.True(File.Exists(dest));
-        Assert.Equal("{\"a\":1}", File.ReadAllText(dest));
-        Assert.True(File.Exists(source));
-    }
-
-    [Fact]
-    public void TryMigrateSettingsFileIfNeeded_WhenDestinationExists_DoesNotOverwrite()
-    {
-        string root = CreateTempDir();
-        string source = Path.Combine(root, "old", "settings.json");
-        string dest = Path.Combine(root, "data", "settings.json");
-
-        Directory.CreateDirectory(Path.GetDirectoryName(source)!);
-        Directory.CreateDirectory(Path.GetDirectoryName(dest)!);
-        File.WriteAllText(source, "{\"old\":1}");
-        File.WriteAllText(dest, "{\"new\":2}");
-
-        SettingsMigrationResult result = AppDataPaths.TryMigrateSettingsFileIfNeeded(source, dest);
-
-        Assert.False(result.Migrated);
-        Assert.Equal("{\"new\":2}", File.ReadAllText(dest));
-    }
 }
-

--- a/WindBoard.Tests/Settings/AppSettingsServiceTests.cs
+++ b/WindBoard.Tests/Settings/AppSettingsServiceTests.cs
@@ -1,0 +1,201 @@
+using System;
+using System.IO;
+using System.Reflection;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using WindBoard.Settings;
+using Xunit;
+
+namespace WindBoard.Tests.Settings;
+
+public sealed class AppSettingsServiceTests
+{
+    [Fact]
+    public async Task ExportToFileAsync_WritesCurrentSettingsSnapshotToSelectedJson()
+    {
+        string root = CreateTempDirectory();
+        try
+        {
+            string defaultSettingsPath = Path.Combine(root, "data", "settings.json");
+            string exportPath = Path.Combine(root, "backup", "windboard-settings.json");
+            AppSettingsService service = CreateService(defaultSettingsPath);
+
+            service.Update(settings =>
+            {
+                settings.General.LanguagePreference = AppLanguagePreferenceParser.EnglishValue;
+                settings.General.Updates.AutoCheckInterval = UpdateCheckIntervalParser.MonthlyValue;
+                settings.General.Updates.LastNotifiedVersion = "  v2.5.0  ";
+            });
+
+            await InvokeTaskMethodAsync(service, "ExportToFileAsync", exportPath, CancellationToken.None);
+
+            var exportedStore = new AppSettingsStore(exportPath);
+            AppSettings exported = exportedStore.LoadOrDefault();
+            Assert.Equal(AppLanguagePreferenceParser.EnglishValue, exported.General.LanguagePreference);
+            Assert.Equal(UpdateCheckIntervalParser.MonthlyValue, exported.General.Updates.AutoCheckInterval);
+            Assert.Equal("v2.5.0", exported.General.Updates.LastNotifiedVersion);
+        }
+        finally
+        {
+            DeleteDirectory(root);
+        }
+    }
+
+    [Fact]
+    public async Task ImportFromFileAsync_ReplacesCurrentSettingsAndPersistsNormalizedValues()
+    {
+        string root = CreateTempDirectory();
+        try
+        {
+            string defaultSettingsPath = Path.Combine(root, "data", "settings.json");
+            string importPath = Path.Combine(root, "incoming", "settings.json");
+            AppSettingsService service = CreateService(defaultSettingsPath);
+
+            service.SetLanguagePreference(AppLanguagePreferenceParser.EnglishValue);
+            service.SetUpdateCheckInterval(UpdateCheckInterval.Monthly);
+            await service.SaveAsync();
+
+            Directory.CreateDirectory(Path.GetDirectoryName(importPath)!);
+            await File.WriteAllTextAsync(
+                importPath,
+                """
+                {
+                  "general": {
+                    "languagePreference": "  zh_CN  ",
+                    "updates": {
+                      "autoCheckInterval": "invalid"
+                    }
+                  },
+                  "diagnostics": {
+                    "logging": {
+                      "retentionDays": 999
+                    }
+                  }
+                }
+                """);
+
+            await InvokeTaskMethodAsync(service, "ImportFromFileAsync", importPath, CancellationToken.None);
+
+            Assert.Equal(AppLanguagePreferenceParser.ChineseValue, service.GetLanguagePreference());
+            Assert.Equal(UpdateCheckInterval.Weekly, service.GetUpdateCheckInterval());
+            Assert.Equal(365, service.GetLoggingSettingsSnapshot().RetentionDays);
+
+            AppSettings persisted = new AppSettingsStore(defaultSettingsPath).LoadOrDefault();
+            Assert.Equal(AppLanguagePreferenceParser.ChineseValue, persisted.General.LanguagePreference);
+            Assert.Equal(UpdateCheckIntervalParser.WeeklyValue, persisted.General.Updates.AutoCheckInterval);
+            Assert.Equal(365, persisted.Diagnostics.Logging.RetentionDays);
+        }
+        finally
+        {
+            DeleteDirectory(root);
+        }
+    }
+
+    [Fact]
+    public async Task ResetToDefaultsAsync_RestoresDefaultSettingsAndPersists()
+    {
+        string root = CreateTempDirectory();
+        try
+        {
+            string defaultSettingsPath = Path.Combine(root, "data", "settings.json");
+            AppSettingsService service = CreateService(defaultSettingsPath);
+
+            service.SetLanguagePreference(AppLanguagePreferenceParser.EnglishValue);
+            service.SetStartupWindowMode(StartupWindowMode.FullScreen);
+            service.SetEnterScreenAnnotationWhenMinimized(false);
+            await service.SaveAsync();
+
+            await InvokeTaskMethodAsync(service, "ResetToDefaultsAsync", CancellationToken.None);
+
+            Assert.Equal(AppLanguagePreferenceParser.SystemValue, service.GetLanguagePreference());
+            Assert.Equal(StartupWindowMode.Windowed, service.GetStartupWindowMode());
+            Assert.True(service.GetEnterScreenAnnotationWhenMinimized());
+            Assert.Equal(UpdateCheckInterval.Weekly, service.GetUpdateCheckInterval());
+
+            AppSettings persisted = new AppSettingsStore(defaultSettingsPath).LoadOrDefault();
+            Assert.Equal(AppLanguagePreferenceParser.SystemValue, persisted.General.LanguagePreference);
+            Assert.Equal(StartupWindowModeParser.WindowedValue, persisted.General.StartupWindowMode);
+            Assert.True(persisted.General.EnterScreenAnnotationWhenMinimized);
+            Assert.Equal(UpdateCheckIntervalParser.WeeklyValue, persisted.General.Updates.AutoCheckInterval);
+        }
+        finally
+        {
+            DeleteDirectory(root);
+        }
+    }
+
+    [Fact]
+    public async Task ImportFromFileAsync_ThrowsOnInvalidJson_AndKeepsCurrentSettings()
+    {
+        string root = CreateTempDirectory();
+        try
+        {
+            string defaultSettingsPath = Path.Combine(root, "data", "settings.json");
+            string importPath = Path.Combine(root, "incoming", "invalid-settings.json");
+            AppSettingsService service = CreateService(defaultSettingsPath);
+
+            service.SetLanguagePreference(AppLanguagePreferenceParser.EnglishValue);
+
+            Directory.CreateDirectory(Path.GetDirectoryName(importPath)!);
+            await File.WriteAllTextAsync(importPath, "{ invalid json ");
+
+            JsonException ex = await Assert.ThrowsAsync<JsonException>(
+                () => InvokeTaskMethodAsync(service, "ImportFromFileAsync", importPath, CancellationToken.None));
+
+            Assert.NotNull(ex);
+            Assert.Equal(AppLanguagePreferenceParser.EnglishValue, service.GetLanguagePreference());
+        }
+        finally
+        {
+            DeleteDirectory(root);
+        }
+    }
+
+    private static AppSettingsService CreateService(string settingsPath)
+    {
+        var store = new AppSettingsStore(settingsPath);
+        ConstructorInfo? ctor = typeof(AppSettingsService).GetConstructor(
+            BindingFlags.Instance | BindingFlags.NonPublic,
+            binder: null,
+            [typeof(AppSettingsStore)],
+            modifiers: null);
+
+        Assert.NotNull(ctor);
+        return Assert.IsType<AppSettingsService>(ctor.Invoke([store]));
+    }
+
+    private static async Task InvokeTaskMethodAsync(object target, string methodName, params object[] args)
+    {
+        MethodInfo? method = target.GetType().GetMethod(
+            methodName,
+            BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
+
+        Assert.NotNull(method);
+
+        try
+        {
+            var task = Assert.IsAssignableFrom<Task>(method.Invoke(target, args));
+            await task.ConfigureAwait(false);
+        }
+        catch (TargetInvocationException ex) when (ex.InnerException is not null)
+        {
+            throw ex.InnerException;
+        }
+    }
+
+    private static string CreateTempDirectory()
+    {
+        string path = Path.Combine(Path.GetTempPath(), "WindBoard.Tests", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(path);
+        return path;
+    }
+
+    private static void DeleteDirectory(string path)
+    {
+        if (Directory.Exists(path))
+        {
+            Directory.Delete(path, recursive: true);
+        }
+    }
+}

--- a/WindBoard.Tests/Settings/AppSettingsServiceTests.cs
+++ b/WindBoard.Tests/Settings/AppSettingsServiceTests.cs
@@ -1,6 +1,5 @@
 using System;
 using System.IO;
-using System.Reflection;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
@@ -28,7 +27,7 @@ public sealed class AppSettingsServiceTests
                 settings.General.Updates.LastNotifiedVersion = "  v2.5.0  ";
             });
 
-            await InvokeTaskMethodAsync(service, "ExportToFileAsync", exportPath, CancellationToken.None);
+            await service.ExportToFileAsync(exportPath, CancellationToken.None);
 
             var exportedStore = new AppSettingsStore(exportPath);
             AppSettings exported = exportedStore.LoadOrDefault();
@@ -75,7 +74,7 @@ public sealed class AppSettingsServiceTests
                 }
                 """);
 
-            await InvokeTaskMethodAsync(service, "ImportFromFileAsync", importPath, CancellationToken.None);
+            await service.ImportFromFileAsync(importPath, CancellationToken.None);
 
             Assert.Equal(AppLanguagePreferenceParser.ChineseValue, service.GetLanguagePreference());
             Assert.Equal(UpdateCheckInterval.Weekly, service.GetUpdateCheckInterval());
@@ -106,7 +105,7 @@ public sealed class AppSettingsServiceTests
             service.SetEnterScreenAnnotationWhenMinimized(false);
             await service.SaveAsync();
 
-            await InvokeTaskMethodAsync(service, "ResetToDefaultsAsync", CancellationToken.None);
+            await service.ResetToDefaultsAsync(CancellationToken.None);
 
             Assert.Equal(AppLanguagePreferenceParser.SystemValue, service.GetLanguagePreference());
             Assert.Equal(StartupWindowMode.Windowed, service.GetStartupWindowMode());
@@ -141,7 +140,7 @@ public sealed class AppSettingsServiceTests
             await File.WriteAllTextAsync(importPath, "{ invalid json ");
 
             JsonException ex = await Assert.ThrowsAsync<JsonException>(
-                () => InvokeTaskMethodAsync(service, "ImportFromFileAsync", importPath, CancellationToken.None));
+                () => service.ImportFromFileAsync(importPath, CancellationToken.None));
 
             Assert.NotNull(ex);
             Assert.Equal(AppLanguagePreferenceParser.EnglishValue, service.GetLanguagePreference());
@@ -155,33 +154,7 @@ public sealed class AppSettingsServiceTests
     private static AppSettingsService CreateService(string settingsPath)
     {
         var store = new AppSettingsStore(settingsPath);
-        ConstructorInfo? ctor = typeof(AppSettingsService).GetConstructor(
-            BindingFlags.Instance | BindingFlags.NonPublic,
-            binder: null,
-            [typeof(AppSettingsStore)],
-            modifiers: null);
-
-        Assert.NotNull(ctor);
-        return Assert.IsType<AppSettingsService>(ctor.Invoke([store]));
-    }
-
-    private static async Task InvokeTaskMethodAsync(object target, string methodName, params object[] args)
-    {
-        MethodInfo? method = target.GetType().GetMethod(
-            methodName,
-            BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
-
-        Assert.NotNull(method);
-
-        try
-        {
-            var task = Assert.IsAssignableFrom<Task>(method.Invoke(target, args));
-            await task.ConfigureAwait(false);
-        }
-        catch (TargetInvocationException ex) when (ex.InnerException is not null)
-        {
-            throw ex.InnerException;
-        }
+        return new AppSettingsService(store);
     }
 
     private static string CreateTempDirectory()

--- a/WindBoard/App.xaml.cs
+++ b/WindBoard/App.xaml.cs
@@ -92,9 +92,6 @@ namespace WindBoard
                 AppLog.Warn("Fonts", "获取 Application.Resources 失败，将跳过图标字体资源覆盖", ex);
             }
 
-            // 便携版首次启动迁移：确保 settings.json 能优先落到 {AppBase}\data 下。
-            SettingsMigrationResult settingsMigration = AppDataPaths.TryMigratePortableSettingsIfNeeded();
-
             AppSettingsService.Instance.Load();
 
             // 应用语言偏好：必须在创建任何 Window/加载任何 XAML 前执行，否则 LocExtension 的取值可能会缓存旧语言。
@@ -166,27 +163,13 @@ namespace WindBoard
             }
 
             // 启动完成后再弹提醒：避免窗口尚未就绪时应用内弹条控件未挂载，导致提醒丢失。
-            TryRemindAppDataIssuesIfNeeded(_window, settingsMigration);
+            TryRemindAppDataIssuesIfNeeded(_window);
         }
 
-        private static void TryRemindAppDataIssuesIfNeeded(Window window, SettingsMigrationResult settingsMigration)
+        private static void TryRemindAppDataIssuesIfNeeded(Window window)
         {
             try
             {
-                if (settingsMigration.Migrated)
-                {
-                    AppReminderService.Instance.RemindOncePerSignature(
-                        window,
-                        signature: "Data:SettingsMigrated",
-                        new AppReminderMessage
-                        {
-                            Title = L10n.Get("Reminder_Data_SettingsMigrated_Title"),
-                            Body = L10n.Get("Reminder_Data_SettingsMigrated_Body_Fmt"),
-                            Severity = AppReminderSeverity.Info,
-                            ClickAction = AppReminderClickAction.OpenAppDataRootDirectory,
-                        });
-                }
-
                 if (AppDataPaths.InstallKind == AppInstallKind.Portable && !AppDataPaths.UsingPortableDataDirectory)
                 {
                     AppReminderService.Instance.RemindOncePerSignature(

--- a/WindBoard/Localization/en-US/Reminder.resx
+++ b/WindBoard/Localization/en-US/Reminder.resx
@@ -38,12 +38,6 @@
   <data name="Reminder_Update_Available_Body" xml:space="preserve">
     <value>Open "Settings - About - Check for updates" to get the download link.</value>
   </data>
-  <data name="Reminder_Data_SettingsMigrated_Title" xml:space="preserve">
-    <value>First launch of the portable version: Local settings have been migrated to the data directory.</value>
-  </data>
-  <data name="Reminder_Data_SettingsMigrated_Body_Fmt" xml:space="preserve">
-    <value>Click this notification to open the current data folder.</value>
-  </data>
   <data name="Reminder_Data_PortableNotWritable_Title" xml:space="preserve">
     <value>Portable data folder is not writable</value>
   </data>

--- a/WindBoard/Localization/en-US/Settings.resx
+++ b/WindBoard/Localization/en-US/Settings.resx
@@ -158,6 +158,67 @@
   <data name="Settings_About_Version" xml:space="preserve">
     <value>Version</value>
   </data>
+  <data name="Settings_About_SettingsManagement_SectionTitle" xml:space="preserve">
+    <value>Settings management</value>
+  </data>
+  <data name="Settings_About_SettingsManagement_Entry_Description" xml:space="preserve">
+    <value>Import, export, or reset settings to default</value>
+  </data>
+  <data name="Settings_About_SettingsManagement_Export_Title" xml:space="preserve">
+    <value>Export settings</value>
+  </data>
+  <data name="Settings_About_SettingsManagement_Export_Description" xml:space="preserve">
+    <value>Export all current settings to a JSON file</value>
+  </data>
+  <data name="Settings_About_SettingsManagement_Import_Title" xml:space="preserve">
+    <value>Import settings</value>
+  </data>
+  <data name="Settings_About_SettingsManagement_Import_Description" xml:space="preserve">
+    <value>Import a JSON file and overwrite all current settings</value>
+  </data>
+  <data name="Settings_About_SettingsManagement_Reset_Title" xml:space="preserve">
+    <value>Reset settings to default</value>
+  </data>
+  <data name="Settings_About_SettingsManagement_Reset_Description" xml:space="preserve">
+    <value>Clear current settings and restore default values</value>
+  </data>
+  <data name="Settings_About_SettingsManagement_FileType" xml:space="preserve">
+    <value>Settings JSON file</value>
+  </data>
+  <data name="Settings_About_SettingsManagement_OverwriteExport_Content_Fmt" xml:space="preserve">
+    <value>File already exists: {0}
+Overwrite the exported settings file?</value>
+  </data>
+  <data name="Settings_About_SettingsManagement_ImportConfirm_Title" xml:space="preserve">
+    <value>Confirm import settings</value>
+  </data>
+  <data name="Settings_About_SettingsManagement_ImportConfirm_Content_Fmt" xml:space="preserve">
+    <value>The following file will be imported and all current settings will be overwritten:
+{0}
+
+This action will be saved to the current device immediately. Continue?</value>
+  </data>
+  <data name="Settings_About_SettingsManagement_ResetConfirm_Title" xml:space="preserve">
+    <value>Confirm reset settings</value>
+  </data>
+  <data name="Settings_About_SettingsManagement_ResetConfirm_Content" xml:space="preserve">
+    <value>All current settings will be restored to default values, and existing settings records will be cleared. This action will be saved immediately. Continue?</value>
+  </data>
+  <data name="Settings_About_SettingsManagement_Exported_Fmt" xml:space="preserve">
+    <value>Settings exported: {0}</value>
+  </data>
+  <data name="Settings_About_SettingsManagement_Imported_Fmt" xml:space="preserve">
+    <value>Settings imported: {0}</value>
+  </data>
+  <data name="Settings_About_SettingsManagement_ResetCompleted" xml:space="preserve">
+    <value>Settings restored to default</value>
+  </data>
+  <data name="Settings_About_SettingsManagement_ImportInvalid_Message" xml:space="preserve">
+    <value>The selected settings file is invalid or malformed.</value>
+  </data>
+  <data name="Settings_About_SettingsManagement_ActionFailed_Fmt" xml:space="preserve">
+    <value>Action failed: {0}</value>
+  </data>
   <data name="Settings_About_AutoCheckUpdates" xml:space="preserve">
     <value>Automatically check for updates</value>
   </data>

--- a/WindBoard/Localization/en-US/Settings.resx
+++ b/WindBoard/Localization/en-US/Settings.resx
@@ -219,6 +219,21 @@ This action will be saved to the current device immediately. Continue?</value>
   <data name="Settings_About_SettingsManagement_ActionFailed_Fmt" xml:space="preserve">
     <value>Action failed: {0}</value>
   </data>
+  <data name="Settings_About_SettingsManagement_SelectedPathInvalid_Message" xml:space="preserve">
+    <value>Can't read the selected settings file path.</value>
+  </data>
+  <data name="Settings_About_SettingsManagement_ImportFileUnavailable_Message" xml:space="preserve">
+    <value>The selected settings file doesn't exist or is unavailable.</value>
+  </data>
+  <data name="Settings_About_SettingsManagement_ExportFailed_Message" xml:space="preserve">
+    <value>Failed to export settings. Please try again later.</value>
+  </data>
+  <data name="Settings_About_SettingsManagement_ImportFailed_Message" xml:space="preserve">
+    <value>Failed to import settings. Check the selected file and try again.</value>
+  </data>
+  <data name="Settings_About_SettingsManagement_ResetFailed_Message" xml:space="preserve">
+    <value>Failed to restore default settings. Please try again later.</value>
+  </data>
   <data name="Settings_About_AutoCheckUpdates" xml:space="preserve">
     <value>Automatically check for updates</value>
   </data>

--- a/WindBoard/Localization/zh-CN/Reminder.resx
+++ b/WindBoard/Localization/zh-CN/Reminder.resx
@@ -38,12 +38,6 @@
   <data name="Reminder_Update_Available_Body" xml:space="preserve">
     <value>打开“设置-关于-检查更新”获取下载链接。</value>
   </data>
-  <data name="Reminder_Data_SettingsMigrated_Title" xml:space="preserve">
-    <value>首次启动便携版，已迁移本机设置到 data 目录</value>
-  </data>
-  <data name="Reminder_Data_SettingsMigrated_Body_Fmt" xml:space="preserve">
-    <value>点击此提醒打开当前数据目录。</value>
-  </data>
   <data name="Reminder_Data_PortableNotWritable_Title" xml:space="preserve">
     <value>便携版 data 目录不可写</value>
   </data>

--- a/WindBoard/Localization/zh-CN/Settings.resx
+++ b/WindBoard/Localization/zh-CN/Settings.resx
@@ -158,6 +158,67 @@
   <data name="Settings_About_Version" xml:space="preserve">
     <value>版本</value>
   </data>
+  <data name="Settings_About_SettingsManagement_SectionTitle" xml:space="preserve">
+    <value>设置管理</value>
+  </data>
+  <data name="Settings_About_SettingsManagement_Entry_Description" xml:space="preserve">
+    <value>导入、导出或恢复默认设置</value>
+  </data>
+  <data name="Settings_About_SettingsManagement_Export_Title" xml:space="preserve">
+    <value>导出设置</value>
+  </data>
+  <data name="Settings_About_SettingsManagement_Export_Description" xml:space="preserve">
+    <value>导出当前全部设置到 JSON 文件</value>
+  </data>
+  <data name="Settings_About_SettingsManagement_Import_Title" xml:space="preserve">
+    <value>导入设置</value>
+  </data>
+  <data name="Settings_About_SettingsManagement_Import_Description" xml:space="preserve">
+    <value>从 JSON 文件导入并覆盖当前全部设置</value>
+  </data>
+  <data name="Settings_About_SettingsManagement_Reset_Title" xml:space="preserve">
+    <value>恢复默认设置</value>
+  </data>
+  <data name="Settings_About_SettingsManagement_Reset_Description" xml:space="preserve">
+    <value>清空当前设置并恢复默认值</value>
+  </data>
+  <data name="Settings_About_SettingsManagement_FileType" xml:space="preserve">
+    <value>设置 JSON 文件</value>
+  </data>
+  <data name="Settings_About_SettingsManagement_OverwriteExport_Content_Fmt" xml:space="preserve">
+    <value>文件已存在：{0}
+是否覆盖导出的设置文件？</value>
+  </data>
+  <data name="Settings_About_SettingsManagement_ImportConfirm_Title" xml:space="preserve">
+    <value>确认导入设置</value>
+  </data>
+  <data name="Settings_About_SettingsManagement_ImportConfirm_Content_Fmt" xml:space="preserve">
+    <value>即将从以下文件导入设置，并覆盖当前全部设置：
+{0}
+
+此操作会立即保存到当前设备，是否继续？</value>
+  </data>
+  <data name="Settings_About_SettingsManagement_ResetConfirm_Title" xml:space="preserve">
+    <value>确认恢复默认设置</value>
+  </data>
+  <data name="Settings_About_SettingsManagement_ResetConfirm_Content" xml:space="preserve">
+    <value>当前全部设置将恢复为默认值，并清空现有设置记录。此操作会立即保存，是否继续？</value>
+  </data>
+  <data name="Settings_About_SettingsManagement_Exported_Fmt" xml:space="preserve">
+    <value>已导出设置：{0}</value>
+  </data>
+  <data name="Settings_About_SettingsManagement_Imported_Fmt" xml:space="preserve">
+    <value>已导入设置：{0}</value>
+  </data>
+  <data name="Settings_About_SettingsManagement_ResetCompleted" xml:space="preserve">
+    <value>已恢复默认设置</value>
+  </data>
+  <data name="Settings_About_SettingsManagement_ImportInvalid_Message" xml:space="preserve">
+    <value>选中的设置文件无效或格式不正确。</value>
+  </data>
+  <data name="Settings_About_SettingsManagement_ActionFailed_Fmt" xml:space="preserve">
+    <value>操作失败：{0}</value>
+  </data>
   <data name="Settings_About_AutoCheckUpdates" xml:space="preserve">
     <value>自动检查更新</value>
   </data>

--- a/WindBoard/Localization/zh-CN/Settings.resx
+++ b/WindBoard/Localization/zh-CN/Settings.resx
@@ -219,6 +219,21 @@
   <data name="Settings_About_SettingsManagement_ActionFailed_Fmt" xml:space="preserve">
     <value>操作失败：{0}</value>
   </data>
+  <data name="Settings_About_SettingsManagement_SelectedPathInvalid_Message" xml:space="preserve">
+    <value>无法读取所选设置文件路径。</value>
+  </data>
+  <data name="Settings_About_SettingsManagement_ImportFileUnavailable_Message" xml:space="preserve">
+    <value>选中的设置文件不存在或不可用。</value>
+  </data>
+  <data name="Settings_About_SettingsManagement_ExportFailed_Message" xml:space="preserve">
+    <value>导出设置失败。请稍后重试。</value>
+  </data>
+  <data name="Settings_About_SettingsManagement_ImportFailed_Message" xml:space="preserve">
+    <value>导入设置失败。请检查所选文件后重试。</value>
+  </data>
+  <data name="Settings_About_SettingsManagement_ResetFailed_Message" xml:space="preserve">
+    <value>恢复默认设置失败。请稍后重试。</value>
+  </data>
   <data name="Settings_About_AutoCheckUpdates" xml:space="preserve">
     <value>自动检查更新</value>
   </data>

--- a/WindBoard/Persistence/AppDataPaths.cs
+++ b/WindBoard/Persistence/AppDataPaths.cs
@@ -1,6 +1,5 @@
 using System;
 using System.IO;
-using WindBoard.Logging;
 using WindBoard.Updates;
 
 namespace WindBoard.Persistence
@@ -133,95 +132,6 @@ namespace WindBoard.Persistence
                 DownloadsDirectory = downloadsDir,
             };
         }
-
-        /// <summary>
-        /// 仅在便携版首次启动时迁移 settings.json：
-        /// - 若 data/settings.json 不存在
-        /// - 且 %LocalAppData%/WindBoard/settings.json 存在
-        /// 则复制一份到 data 目录（不覆盖）。
-        /// </summary>
-        internal static SettingsMigrationResult TryMigratePortableSettingsIfNeeded()
-        {
-            AppDataPathsSnapshot snapshot = GetSnapshot();
-            if (!snapshot.UsingPortableDataDirectory)
-            {
-                return default;
-            }
-
-            SettingsMigrationResult result = TryMigrateSettingsFileIfNeeded(
-                sourcePath: snapshot.LocalAppDataSettingsFilePath,
-                destinationPath: snapshot.SettingsFilePath);
-
-            if (result.Migrated)
-            {
-                AppLog.Info(
-                    "Settings",
-                    $"已迁移 settings.json 到便携版 data 目录：from='{snapshot.LocalAppDataSettingsFilePath}', to='{snapshot.SettingsFilePath}'");
-            }
-            else if (!string.IsNullOrWhiteSpace(result.ErrorMessage))
-            {
-                AppLog.Warn(
-                    "Settings",
-                    $"迁移 settings.json 失败，将继续使用现有设置：from='{snapshot.LocalAppDataSettingsFilePath}', to='{snapshot.SettingsFilePath}', error='{result.ErrorMessage}'");
-            }
-
-            return result;
-        }
-
-        internal static SettingsMigrationResult TryMigrateSettingsFileIfNeeded(string sourcePath, string destinationPath)
-        {
-            string source = (sourcePath ?? string.Empty).Trim();
-            string dest = (destinationPath ?? string.Empty).Trim();
-
-            if (string.IsNullOrWhiteSpace(source) || string.IsNullOrWhiteSpace(dest))
-            {
-                return new SettingsMigrationResult
-                {
-                    Migrated = false,
-                    ErrorMessage = "sourcePath/destinationPath 不能为空。",
-                };
-            }
-
-            try
-            {
-                string sourceFull = Path.GetFullPath(source);
-                string destFull = Path.GetFullPath(dest);
-
-                // 同一路径无需迁移：直接返回。
-                if (string.Equals(sourceFull, destFull, StringComparison.OrdinalIgnoreCase))
-                {
-                    return default;
-                }
-
-                if (File.Exists(destFull))
-                {
-                    return default;
-                }
-
-                if (!File.Exists(sourceFull))
-                {
-                    return default;
-                }
-
-                string? dir = Path.GetDirectoryName(destFull);
-                if (!string.IsNullOrWhiteSpace(dir))
-                {
-                    Directory.CreateDirectory(dir);
-                }
-
-                File.Copy(sourceFull, destFull, overwrite: false);
-                return new SettingsMigrationResult { Migrated = true };
-            }
-            catch (Exception ex)
-            {
-                return new SettingsMigrationResult
-                {
-                    Migrated = false,
-                    ErrorMessage = ex.GetType().Name + ": " + ex.Message,
-                };
-            }
-        }
-
         private static (bool ok, string? errorMessage) TryEnsureDirectoryWritable(string directory)
         {
             string dir = (directory ?? string.Empty).Trim();
@@ -322,11 +232,5 @@ namespace WindBoard.Persistence
         internal string LogsDirectory { get; init; } = string.Empty;
         internal string CamouflageCacheDirectory { get; init; } = string.Empty;
         internal string DownloadsDirectory { get; init; } = string.Empty;
-    }
-
-    internal readonly struct SettingsMigrationResult
-    {
-        internal bool Migrated { get; init; }
-        internal string? ErrorMessage { get; init; }
     }
 }

--- a/WindBoard/Settings/AppSettingsService.cs
+++ b/WindBoard/Settings/AppSettingsService.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
 using Windows.UI;
@@ -445,6 +446,37 @@ namespace WindBoard.Settings
             });
         }
 
+        internal async Task ExportToFileAsync(string filePath, CancellationToken cancellationToken = default)
+        {
+            string path = NormalizeExternalFilePath(filePath);
+
+            AppSettings snapshot;
+            lock (_gate)
+            {
+                snapshot = AppSettingsCloner.Clone(Current);
+            }
+
+            await SaveInternalAsync(snapshot, new AppSettingsStore(path), cancellationToken).ConfigureAwait(false);
+        }
+
+        internal async Task ImportFromFileAsync(string filePath, CancellationToken cancellationToken = default)
+        {
+            string path = NormalizeExternalFilePath(filePath);
+            string json = await File.ReadAllTextAsync(path, cancellationToken).ConfigureAwait(false);
+
+            var report = new SettingsNormalizationReport();
+            AppSettings imported = AppSettingsStore.Deserialize(json, report);
+            ReplaceAllCore(imported, report, requestSaveDebounced: false);
+            await SaveAsync(cancellationToken).ConfigureAwait(false);
+        }
+
+        internal async Task ResetToDefaultsAsync(CancellationToken cancellationToken = default)
+        {
+            var report = new SettingsNormalizationReport();
+            ReplaceAllCore(new AppSettings(), report, requestSaveDebounced: false);
+            await SaveAsync(cancellationToken).ConfigureAwait(false);
+        }
+
         internal Task SaveAsync(CancellationToken cancellationToken = default)
         {
             AppSettings snapshot;
@@ -456,7 +488,7 @@ namespace WindBoard.Settings
                 snapshot = AppSettingsCloner.Clone(Current);
             }
 
-            return SaveInternalAsync(snapshot, cancellationToken);
+            return SaveInternalAsync(snapshot, _store, cancellationToken);
         }
 
         private void RequestSaveDebounced()
@@ -493,12 +525,58 @@ namespace WindBoard.Settings
             });
         }
 
-        private async Task SaveInternalAsync(AppSettings snapshot, CancellationToken cancellationToken)
+        private void ReplaceAllCore(AppSettings settings, SettingsNormalizationReport report, bool requestSaveDebounced)
+        {
+            if (settings is null)
+            {
+                throw new ArgumentNullException(nameof(settings));
+            }
+
+            if (report is null)
+            {
+                throw new ArgumentNullException(nameof(report));
+            }
+
+            // 先复制再归一化，避免外部继续持有引用并修改内部状态。
+            AppSettings next = AppSettingsCloner.Clone(settings);
+            AppSettingsStore.NormalizeInPlace(next, report);
+
+            lock (_gate)
+            {
+                Current = next;
+
+                // 导入/恢复默认后，旧的快捷键归一化问题不再相关，这里整体替换为新快照对应的问题列表。
+                _pendingKeyboardShortcutIssues.Clear();
+                if (report.KeyboardShortcutIssues.Count > 0)
+                {
+                    _pendingKeyboardShortcutIssues.AddRange(report.KeyboardShortcutIssues);
+                }
+            }
+
+            Changed?.Invoke(this, EventArgs.Empty);
+            if (requestSaveDebounced)
+            {
+                RequestSaveDebounced();
+            }
+        }
+
+        private static string NormalizeExternalFilePath(string filePath)
+        {
+            string path = (filePath ?? string.Empty).Trim();
+            if (string.IsNullOrWhiteSpace(path))
+            {
+                throw new ArgumentException("文件路径不能为空。", nameof(filePath));
+            }
+
+            return path;
+        }
+
+        private async Task SaveInternalAsync(AppSettings snapshot, AppSettingsStore targetStore, CancellationToken cancellationToken)
         {
             await _ioGate.WaitAsync(cancellationToken).ConfigureAwait(false);
             try
             {
-                _store.Save(snapshot);
+                targetStore.Save(snapshot);
             }
             finally
             {

--- a/WindBoard/Settings/AppSettingsService.cs
+++ b/WindBoard/Settings/AppSettingsService.cs
@@ -40,7 +40,7 @@ namespace WindBoard.Settings
 
         internal event EventHandler? Changed;
 
-        private AppSettingsService(AppSettingsStore store)
+        internal AppSettingsService(AppSettingsStore store)
         {
             _store = store ?? throw new ArgumentNullException(nameof(store));
         }

--- a/WindBoard/Settings/AppSettingsStore.cs
+++ b/WindBoard/Settings/AppSettingsStore.cs
@@ -60,8 +60,7 @@ namespace WindBoard.Settings
                 }
 
                 string json = File.ReadAllText(FilePath);
-                AppSettings? settings = JsonSerializer.Deserialize<AppSettings>(json, JsonOptions);
-                return NormalizeInPlace(settings ?? new AppSettings(), report);
+                return Deserialize(json, report);
             }
             catch (Exception ex)
             {
@@ -78,8 +77,7 @@ namespace WindBoard.Settings
                 throw new ArgumentNullException(nameof(settings));
             }
 
-            AppSettings snapshot = CloneAndNormalize(settings);
-            string json = JsonSerializer.Serialize(snapshot, JsonOptions);
+            string json = Serialize(settings);
 
             string? directory = Path.GetDirectoryName(FilePath);
             if (!string.IsNullOrEmpty(directory))
@@ -90,6 +88,28 @@ namespace WindBoard.Settings
             string tempPath = FilePath + ".tmp";
             File.WriteAllText(tempPath, json);
             File.Move(tempPath, FilePath, overwrite: true);
+        }
+
+        internal static AppSettings Deserialize(string json, SettingsNormalizationReport? report = null)
+        {
+            if (json is null)
+            {
+                throw new ArgumentNullException(nameof(json));
+            }
+
+            AppSettings? settings = JsonSerializer.Deserialize<AppSettings>(json, JsonOptions);
+            return NormalizeInPlace(settings ?? new AppSettings(), report);
+        }
+
+        internal static string Serialize(AppSettings settings)
+        {
+            if (settings is null)
+            {
+                throw new ArgumentNullException(nameof(settings));
+            }
+
+            AppSettings snapshot = CloneAndNormalize(settings);
+            return JsonSerializer.Serialize(snapshot, JsonOptions);
         }
 
         /// <summary>

--- a/WindBoard/Settings/Pages/AboutSettingsPage.Navigation.cs
+++ b/WindBoard/Settings/Pages/AboutSettingsPage.Navigation.cs
@@ -1,0 +1,12 @@
+using Microsoft.UI.Xaml;
+
+namespace WindBoard.Settings.Pages
+{
+    public sealed partial class AboutSettingsPage
+    {
+        private void OnSettingsManagementClicked(object sender, RoutedEventArgs e)
+        {
+            Frame.Navigate(typeof(SettingsManagementPage));
+        }
+    }
+}

--- a/WindBoard/Settings/Pages/AboutSettingsPage.xaml
+++ b/WindBoard/Settings/Pages/AboutSettingsPage.xaml
@@ -52,6 +52,20 @@
                     </controls:SettingsCard.Content>
                 </controls:SettingsCard>
 
+                <controls:SettingsCard
+                    x:Name="SettingsManagementEntryCard"
+                    IsClickEnabled="True"
+                    Click="OnSettingsManagementClicked"
+                    Header="{l10n:Loc Key=Settings_About_SettingsManagement_SectionTitle}"
+                    Description="{l10n:Loc Key=Settings_About_SettingsManagement_Entry_Description}">
+                    <controls:SettingsCard.HeaderIcon>
+                        <FontIcon
+                            FontFamily="{ThemeResource SymbolThemeFontFamily}"
+                            FontSize="16"
+                            Glyph="&#xE713;" />
+                    </controls:SettingsCard.HeaderIcon>
+                </controls:SettingsCard>
+
                 <controls:SettingsCard Header="{l10n:Loc Key=Settings_About_AutoCheckUpdates}">
                     <controls:SettingsCard.Content>
                         <ComboBox

--- a/WindBoard/Settings/Pages/SettingsManagementPage.xaml
+++ b/WindBoard/Settings/Pages/SettingsManagementPage.xaml
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Page
+    x:Class="WindBoard.Settings.Pages.SettingsManagementPage"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:l10n="using:WindBoard.Localization"
+    xmlns:controls="using:CommunityToolkit.WinUI.Controls"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d">
+
+    <Grid>
+        <ScrollViewer>
+            <StackPanel Spacing="16" Padding="24">
+                <TextBlock
+                    Text="{l10n:Loc Key=Settings_About_SettingsManagement_SectionTitle}"
+                    Style="{ThemeResource TitleTextBlockStyle}" />
+
+                <InfoBar
+                    x:Name="SettingsManagementFeedbackBar"
+                    IsOpen="False"
+                    IsClosable="True"
+                    IsIconVisible="True"
+                    Severity="Informational" />
+
+                <controls:SettingsCard
+                    x:Name="ExportSettingsCard"
+                    IsClickEnabled="True"
+                    Click="OnExportSettingsClicked"
+                    Header="{l10n:Loc Key=Settings_About_SettingsManagement_Export_Title}"
+                    Description="{l10n:Loc Key=Settings_About_SettingsManagement_Export_Description}">
+                    <controls:SettingsCard.HeaderIcon>
+                        <FontIcon
+                            FontFamily="{ThemeResource SymbolThemeFontFamily}"
+                            FontSize="16"
+                            Glyph="&#xE898;" />
+                    </controls:SettingsCard.HeaderIcon>
+                </controls:SettingsCard>
+
+                <controls:SettingsCard
+                    x:Name="ImportSettingsCard"
+                    IsClickEnabled="True"
+                    Click="OnImportSettingsClicked"
+                    Header="{l10n:Loc Key=Settings_About_SettingsManagement_Import_Title}"
+                    Description="{l10n:Loc Key=Settings_About_SettingsManagement_Import_Description}">
+                    <controls:SettingsCard.HeaderIcon>
+                        <FontIcon
+                            FontFamily="{ThemeResource SymbolThemeFontFamily}"
+                            FontSize="16"
+                            Glyph="&#xE896;" />
+                    </controls:SettingsCard.HeaderIcon>
+                </controls:SettingsCard>
+
+                <controls:SettingsCard
+                    x:Name="ResetSettingsCard"
+                    IsClickEnabled="True"
+                    Click="OnResetSettingsClicked"
+                    Header="{l10n:Loc Key=Settings_About_SettingsManagement_Reset_Title}"
+                    Description="{l10n:Loc Key=Settings_About_SettingsManagement_Reset_Description}">
+                    <controls:SettingsCard.HeaderIcon>
+                        <FontIcon
+                            FontFamily="{ThemeResource SymbolThemeFontFamily}"
+                            FontSize="16"
+                            Glyph="&#xE72C;" />
+                    </controls:SettingsCard.HeaderIcon>
+                </controls:SettingsCard>
+            </StackPanel>
+        </ScrollViewer>
+    </Grid>
+</Page>

--- a/WindBoard/Settings/Pages/SettingsManagementPage.xaml.cs
+++ b/WindBoard/Settings/Pages/SettingsManagementPage.xaml.cs
@@ -46,19 +46,24 @@ namespace WindBoard.Settings.Pages
                 }
 
                 StorageFile? file = await PickExportSettingsFileWithOverwriteConfirmAsync(hwnd).ConfigureAwait(true);
-                if (file is null)
+                if (!TryGetPickedSettingsPath(file, requireExistingFile: false, out string filePath))
                 {
                     return;
                 }
 
-                await AppSettingsService.Instance.ExportToFileAsync(file.Path, CancellationToken.None).ConfigureAwait(true);
-                AppLog.Info("Settings", $"设置已导出：path='{file.Path}'");
-                ShowSettingsManagementFeedback(InfoBarSeverity.Success, L10n.Format("Settings_About_SettingsManagement_Exported_Fmt", file.Path));
+                await AppSettingsService.Instance.ExportToFileAsync(filePath, CancellationToken.None).ConfigureAwait(true);
+                AppLog.Info("Settings", $"设置已导出：path='{filePath}'");
+                ShowSettingsManagementFeedback(InfoBarSeverity.Success, L10n.Format("Settings_About_SettingsManagement_Exported_Fmt", filePath));
+            }
+            catch (ArgumentException ex)
+            {
+                AppLog.Warn("Settings", "导出设置失败：文件路径无效", ex);
+                ShowSettingsManagementFeedback(InfoBarSeverity.Error, L10n.Get("Settings_About_SettingsManagement_SelectedPathInvalid_Message"));
             }
             catch (Exception ex)
             {
                 AppLog.Warn("Settings", "导出设置失败", ex);
-                ShowSettingsManagementFeedback(InfoBarSeverity.Error, L10n.Format("Settings_About_SettingsManagement_ActionFailed_Fmt", ex.Message));
+                ShowSettingsManagementFeedback(InfoBarSeverity.Error, L10n.Get("Settings_About_SettingsManagement_ExportFailed_Message"));
             }
             finally
             {
@@ -89,20 +94,30 @@ namespace WindBoard.Settings.Pages
                 }
 
                 StorageFile? file = await PickImportSettingsFileAsync(hwnd).ConfigureAwait(true);
-                if (file is null)
+                if (!TryGetPickedSettingsPath(file, requireExistingFile: true, out string filePath))
                 {
                     return;
                 }
 
-                bool confirmed = await ConfirmImportSettingsAsync(file.Path).ConfigureAwait(true);
+                bool confirmed = await ConfirmImportSettingsAsync(filePath).ConfigureAwait(true);
                 if (!confirmed)
                 {
                     return;
                 }
 
-                await AppSettingsService.Instance.ImportFromFileAsync(file.Path, CancellationToken.None).ConfigureAwait(true);
-                AppLog.Info("Settings", $"设置已导入：path='{file.Path}'");
-                ShowSettingsManagementFeedback(InfoBarSeverity.Success, L10n.Format("Settings_About_SettingsManagement_Imported_Fmt", file.Path));
+                await AppSettingsService.Instance.ImportFromFileAsync(filePath, CancellationToken.None).ConfigureAwait(true);
+                AppLog.Info("Settings", $"设置已导入：path='{filePath}'");
+                ShowSettingsManagementFeedback(InfoBarSeverity.Success, L10n.Format("Settings_About_SettingsManagement_Imported_Fmt", filePath));
+            }
+            catch (ArgumentException ex)
+            {
+                AppLog.Warn("Settings", "导入设置失败：文件路径无效", ex);
+                ShowSettingsManagementFeedback(InfoBarSeverity.Error, L10n.Get("Settings_About_SettingsManagement_SelectedPathInvalid_Message"));
+            }
+            catch (FileNotFoundException ex)
+            {
+                AppLog.Warn("Settings", "导入设置失败：文件不存在或不可用", ex);
+                ShowSettingsManagementFeedback(InfoBarSeverity.Error, L10n.Get("Settings_About_SettingsManagement_ImportFileUnavailable_Message"));
             }
             catch (JsonException ex)
             {
@@ -112,7 +127,7 @@ namespace WindBoard.Settings.Pages
             catch (Exception ex)
             {
                 AppLog.Warn("Settings", "导入设置失败", ex);
-                ShowSettingsManagementFeedback(InfoBarSeverity.Error, L10n.Format("Settings_About_SettingsManagement_ActionFailed_Fmt", ex.Message));
+                ShowSettingsManagementFeedback(InfoBarSeverity.Error, L10n.Get("Settings_About_SettingsManagement_ImportFailed_Message"));
             }
             finally
             {
@@ -148,7 +163,7 @@ namespace WindBoard.Settings.Pages
             catch (Exception ex)
             {
                 AppLog.Warn("Settings", "恢复默认设置失败", ex);
-                ShowSettingsManagementFeedback(InfoBarSeverity.Error, L10n.Format("Settings_About_SettingsManagement_ActionFailed_Fmt", ex.Message));
+                ShowSettingsManagementFeedback(InfoBarSeverity.Error, L10n.Get("Settings_About_SettingsManagement_ResetFailed_Message"));
             }
             finally
             {
@@ -202,6 +217,32 @@ namespace WindBoard.Settings.Pages
             SettingsManagementFeedbackBar.Severity = severity;
             SettingsManagementFeedbackBar.Message = message ?? string.Empty;
             SettingsManagementFeedbackBar.IsOpen = true;
+        }
+
+        private bool TryGetPickedSettingsPath(StorageFile? file, bool requireExistingFile, out string filePath)
+        {
+            filePath = string.Empty;
+            if (file is null)
+            {
+                return false;
+            }
+
+            // 文件选择器返回的 Path 在极端场景下可能为空，这里先做 UI 层兜底，
+            // 避免服务层参数异常直接以技术细节形式暴露给用户。
+            filePath = (file.Path ?? string.Empty).Trim();
+            if (string.IsNullOrWhiteSpace(filePath))
+            {
+                ShowSettingsManagementFeedback(InfoBarSeverity.Error, L10n.Get("Settings_About_SettingsManagement_SelectedPathInvalid_Message"));
+                return false;
+            }
+
+            if (requireExistingFile && !File.Exists(filePath))
+            {
+                ShowSettingsManagementFeedback(InfoBarSeverity.Error, L10n.Get("Settings_About_SettingsManagement_ImportFileUnavailable_Message"));
+                return false;
+            }
+
+            return true;
         }
 
         private async Task<StorageFile?> PickExportSettingsFileWithOverwriteConfirmAsync(IntPtr hwnd)
@@ -341,8 +382,9 @@ namespace WindBoard.Settings.Pages
                     return SettingsWindow.Active.Hwnd;
                 }
             }
-            catch
+            catch (Exception ex)
             {
+                AppLog.Debug("Settings", "获取设置管理页宿主窗口句柄失败", ex);
                 return IntPtr.Zero;
             }
 

--- a/WindBoard/Settings/Pages/SettingsManagementPage.xaml.cs
+++ b/WindBoard/Settings/Pages/SettingsManagementPage.xaml.cs
@@ -1,0 +1,352 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Windows.Storage;
+using Windows.Storage.Pickers;
+using WindBoard.Localization;
+using WindBoard.Logging;
+
+namespace WindBoard.Settings.Pages
+{
+    public sealed partial class SettingsManagementPage : Page
+    {
+        private bool _isManagingSettings;
+
+        public SettingsManagementPage()
+        {
+            InitializeComponent();
+        }
+
+        private async void OnExportSettingsClicked(object sender, RoutedEventArgs e)
+        {
+            if (!TryBeginSettingsManagementOperation())
+            {
+                return;
+            }
+
+            try
+            {
+                if (XamlRoot is null)
+                {
+                    ShowSettingsManagementFeedback(InfoBarSeverity.Error, L10n.Get("Common_WindowHandleFailed_Message"));
+                    return;
+                }
+
+                IntPtr hwnd = TryGetHostWindowHandle();
+                if (hwnd == IntPtr.Zero)
+                {
+                    ShowSettingsManagementFeedback(InfoBarSeverity.Error, L10n.Get("Common_WindowHandleFailed_Message"));
+                    return;
+                }
+
+                StorageFile? file = await PickExportSettingsFileWithOverwriteConfirmAsync(hwnd).ConfigureAwait(true);
+                if (file is null)
+                {
+                    return;
+                }
+
+                await AppSettingsService.Instance.ExportToFileAsync(file.Path, CancellationToken.None).ConfigureAwait(true);
+                AppLog.Info("Settings", $"设置已导出：path='{file.Path}'");
+                ShowSettingsManagementFeedback(InfoBarSeverity.Success, L10n.Format("Settings_About_SettingsManagement_Exported_Fmt", file.Path));
+            }
+            catch (Exception ex)
+            {
+                AppLog.Warn("Settings", "导出设置失败", ex);
+                ShowSettingsManagementFeedback(InfoBarSeverity.Error, L10n.Format("Settings_About_SettingsManagement_ActionFailed_Fmt", ex.Message));
+            }
+            finally
+            {
+                EndSettingsManagementOperation();
+            }
+        }
+
+        private async void OnImportSettingsClicked(object sender, RoutedEventArgs e)
+        {
+            if (!TryBeginSettingsManagementOperation())
+            {
+                return;
+            }
+
+            try
+            {
+                if (XamlRoot is null)
+                {
+                    ShowSettingsManagementFeedback(InfoBarSeverity.Error, L10n.Get("Common_WindowHandleFailed_Message"));
+                    return;
+                }
+
+                IntPtr hwnd = TryGetHostWindowHandle();
+                if (hwnd == IntPtr.Zero)
+                {
+                    ShowSettingsManagementFeedback(InfoBarSeverity.Error, L10n.Get("Common_WindowHandleFailed_Message"));
+                    return;
+                }
+
+                StorageFile? file = await PickImportSettingsFileAsync(hwnd).ConfigureAwait(true);
+                if (file is null)
+                {
+                    return;
+                }
+
+                bool confirmed = await ConfirmImportSettingsAsync(file.Path).ConfigureAwait(true);
+                if (!confirmed)
+                {
+                    return;
+                }
+
+                await AppSettingsService.Instance.ImportFromFileAsync(file.Path, CancellationToken.None).ConfigureAwait(true);
+                AppLog.Info("Settings", $"设置已导入：path='{file.Path}'");
+                ShowSettingsManagementFeedback(InfoBarSeverity.Success, L10n.Format("Settings_About_SettingsManagement_Imported_Fmt", file.Path));
+            }
+            catch (JsonException ex)
+            {
+                AppLog.Warn("Settings", "导入设置失败：JSON 无效", ex);
+                ShowSettingsManagementFeedback(InfoBarSeverity.Error, L10n.Get("Settings_About_SettingsManagement_ImportInvalid_Message"));
+            }
+            catch (Exception ex)
+            {
+                AppLog.Warn("Settings", "导入设置失败", ex);
+                ShowSettingsManagementFeedback(InfoBarSeverity.Error, L10n.Format("Settings_About_SettingsManagement_ActionFailed_Fmt", ex.Message));
+            }
+            finally
+            {
+                EndSettingsManagementOperation();
+            }
+        }
+
+        private async void OnResetSettingsClicked(object sender, RoutedEventArgs e)
+        {
+            if (!TryBeginSettingsManagementOperation())
+            {
+                return;
+            }
+
+            try
+            {
+                if (XamlRoot is null)
+                {
+                    ShowSettingsManagementFeedback(InfoBarSeverity.Error, L10n.Get("Common_WindowHandleFailed_Message"));
+                    return;
+                }
+
+                bool confirmed = await ConfirmResetSettingsAsync().ConfigureAwait(true);
+                if (!confirmed)
+                {
+                    return;
+                }
+
+                await AppSettingsService.Instance.ResetToDefaultsAsync(CancellationToken.None).ConfigureAwait(true);
+                AppLog.Info("Settings", "已恢复默认设置");
+                ShowSettingsManagementFeedback(InfoBarSeverity.Success, L10n.Get("Settings_About_SettingsManagement_ResetCompleted"));
+            }
+            catch (Exception ex)
+            {
+                AppLog.Warn("Settings", "恢复默认设置失败", ex);
+                ShowSettingsManagementFeedback(InfoBarSeverity.Error, L10n.Format("Settings_About_SettingsManagement_ActionFailed_Fmt", ex.Message));
+            }
+            finally
+            {
+                EndSettingsManagementOperation();
+            }
+        }
+
+        private bool TryBeginSettingsManagementOperation()
+        {
+            if (_isManagingSettings)
+            {
+                return false;
+            }
+
+            _isManagingSettings = true;
+            SetSettingsManagementUiState(isBusy: true);
+            return true;
+        }
+
+        private void EndSettingsManagementOperation()
+        {
+            _isManagingSettings = false;
+            SetSettingsManagementUiState(isBusy: false);
+        }
+
+        private void SetSettingsManagementUiState(bool isBusy)
+        {
+            if (ExportSettingsCard is not null)
+            {
+                ExportSettingsCard.IsEnabled = !isBusy;
+            }
+
+            if (ImportSettingsCard is not null)
+            {
+                ImportSettingsCard.IsEnabled = !isBusy;
+            }
+
+            if (ResetSettingsCard is not null)
+            {
+                ResetSettingsCard.IsEnabled = !isBusy;
+            }
+        }
+
+        private void ShowSettingsManagementFeedback(InfoBarSeverity severity, string message)
+        {
+            if (SettingsManagementFeedbackBar is null)
+            {
+                return;
+            }
+
+            SettingsManagementFeedbackBar.Severity = severity;
+            SettingsManagementFeedbackBar.Message = message ?? string.Empty;
+            SettingsManagementFeedbackBar.IsOpen = true;
+        }
+
+        private async Task<StorageFile?> PickExportSettingsFileWithOverwriteConfirmAsync(IntPtr hwnd)
+        {
+            if (hwnd == IntPtr.Zero)
+            {
+                return null;
+            }
+
+            var picker = new FileSavePicker();
+            WinRT.Interop.InitializeWithWindow.Initialize(picker, hwnd);
+
+            picker.SuggestedStartLocation = PickerLocationId.DocumentsLibrary;
+            picker.FileTypeChoices.Add(L10n.Get("Settings_About_SettingsManagement_FileType"), new List<string> { ".json" });
+            picker.SuggestedFileName = BuildSuggestedSettingsFileName(DateTimeOffset.Now);
+
+            while (true)
+            {
+                DateTimeOffset pickStarted = DateTimeOffset.Now;
+                StorageFile? file = await picker.PickSaveFileAsync();
+                if (file is null)
+                {
+                    return null;
+                }
+
+                if (!File.Exists(file.Path))
+                {
+                    return file;
+                }
+
+                // WinUI 的 FileSavePicker 可能先创建一个空文件再返回，这里沿用时间窗口做保守判断，避免每次都误弹“覆盖确认”。
+                if (file.DateCreated >= pickStarted - TimeSpan.FromSeconds(2))
+                {
+                    return file;
+                }
+
+                bool overwrite = await ConfirmOverwriteExportFileAsync(file.Path).ConfigureAwait(true);
+                if (overwrite)
+                {
+                    return file;
+                }
+            }
+        }
+
+        private async Task<StorageFile?> PickImportSettingsFileAsync(IntPtr hwnd)
+        {
+            if (hwnd == IntPtr.Zero)
+            {
+                return null;
+            }
+
+            var picker = new FileOpenPicker();
+            WinRT.Interop.InitializeWithWindow.Initialize(picker, hwnd);
+
+            picker.SuggestedStartLocation = PickerLocationId.DocumentsLibrary;
+            picker.FileTypeFilter.Clear();
+            picker.FileTypeFilter.Add(".json");
+            picker.FileTypeFilter.Add("*");
+
+            return await picker.PickSingleFileAsync();
+        }
+
+        private async Task<bool> ConfirmOverwriteExportFileAsync(string filePath)
+        {
+            if (XamlRoot is null)
+            {
+                return false;
+            }
+
+            var dialog = new ContentDialog
+            {
+                Title = L10n.Get("Common_ConfirmOverwrite_Title"),
+                Content = L10n.Format("Settings_About_SettingsManagement_OverwriteExport_Content_Fmt", filePath),
+                PrimaryButtonText = L10n.Get("Common_Overwrite"),
+                CloseButtonText = L10n.Get("Common_Cancel"),
+                DefaultButton = ContentDialogButton.Close,
+                XamlRoot = XamlRoot,
+            };
+
+            return await dialog.ShowAsync() == ContentDialogResult.Primary;
+        }
+
+        private async Task<bool> ConfirmImportSettingsAsync(string filePath)
+        {
+            if (XamlRoot is null)
+            {
+                return false;
+            }
+
+            var dialog = new ContentDialog
+            {
+                Title = L10n.Get("Settings_About_SettingsManagement_ImportConfirm_Title"),
+                Content = L10n.Format("Settings_About_SettingsManagement_ImportConfirm_Content_Fmt", filePath),
+                PrimaryButtonText = L10n.Get("Common_Import"),
+                CloseButtonText = L10n.Get("Common_Cancel"),
+                DefaultButton = ContentDialogButton.Close,
+                XamlRoot = XamlRoot,
+            };
+
+            return await dialog.ShowAsync() == ContentDialogResult.Primary;
+        }
+
+        private async Task<bool> ConfirmResetSettingsAsync()
+        {
+            if (XamlRoot is null)
+            {
+                return false;
+            }
+
+            var dialog = new ContentDialog
+            {
+                Title = L10n.Get("Settings_About_SettingsManagement_ResetConfirm_Title"),
+                Content = L10n.Get("Settings_About_SettingsManagement_ResetConfirm_Content"),
+                PrimaryButtonText = L10n.Get("Common_ResetToDefault"),
+                CloseButtonText = L10n.Get("Common_Cancel"),
+                DefaultButton = ContentDialogButton.Close,
+                XamlRoot = XamlRoot,
+            };
+
+            return await dialog.ShowAsync() == ContentDialogResult.Primary;
+        }
+
+        private static string BuildSuggestedSettingsFileName(DateTimeOffset now)
+        {
+            string date = now.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture);
+            string time = now.ToString("HHmm", CultureInfo.InvariantCulture);
+            return $"WindBoard-settings-{date}-{time}";
+        }
+
+        private static IntPtr TryGetHostWindowHandle()
+        {
+            try
+            {
+                // Page 不能直接拿宿主 Window，这里继续复用 SettingsWindow 的静态活动实例。
+                if (SettingsWindow.Active is not null)
+                {
+                    return SettingsWindow.Active.Hwnd;
+                }
+            }
+            catch
+            {
+                return IntPtr.Zero;
+            }
+
+            return IntPtr.Zero;
+        }
+    }
+}


### PR DESCRIPTION
## Summary by Sourcery

添加面向用户的设置管理功能，并移除旧版便携设置迁移行为。

New Features:
- 支持将当前应用设置导出到用户选择的 JSON 文件。
- 支持从 JSON 文件导入设置，并包含确认、校验以及数值规范化流程。
- 在 UI 中新增将所有设置重置为默认值的能力。

Enhancements:
- 重构设置持久化逻辑，在主存储与外部文件之间共享序列化和规范化逻辑。
- 暴露一个核心设置替换操作，以一致地更新当前快照和待处理的快捷键问题。
- 将“关于”页面的导航入口连接到专门的设置管理页面。

Tests:
- 添加单元测试，覆盖设置导出、导入、重置为默认值行为，以及无效 JSON 的处理。
- 移除与已删除的便携设置迁移逻辑相关的过时测试。

Chores:
- 移除旧版便携设置迁移代码及其相关的用户提醒。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add user-facing settings management capabilities and remove legacy portable settings migration behavior.

New Features:
- Support exporting current application settings to a user-selected JSON file.
- Support importing settings from a JSON file with confirmation, validation, and normalization of values.
- Add the ability to reset all settings to their defaults from the UI.

Enhancements:
- Refactor settings persistence to share serialization and normalization logic between the main store and external files.
- Expose a core settings replacement operation that updates the current snapshot and pending shortcut issues consistently.
- Wire an About page navigation entry to a dedicated settings management page.

Tests:
- Add unit tests covering settings export, import, reset-to-default behavior, and invalid JSON handling.
- Remove obsolete tests related to the deleted portable settings migration logic.

Chores:
- Remove legacy portable settings migration code and its related user reminder.

</details>