### PR TITLE
修复屏幕批注DPI缩放

### DIFF
--- a/WindBoard.Tests/Features/ScreenAnnotation/ScreenAnnotationDisplayTargetTests.cs
+++ b/WindBoard.Tests/Features/ScreenAnnotation/ScreenAnnotationDisplayTargetTests.cs
@@ -37,4 +37,20 @@ public sealed class ScreenAnnotationDisplayTargetTests
         Assert.Equal(200, toolbarBounds.Width);
         Assert.Equal(72, toolbarBounds.Height);
     }
+
+    [Fact]
+    public void GetInitialToolbarBounds_UsesProvidedMargin()
+    {
+        var target = new ScreenAnnotationDisplayTarget(
+            MonitorHandle: nint.Zero,
+            Bounds: new RectInt32(100, 200, 1600, 900),
+            WorkArea: new RectInt32(100, 200, 1600, 900));
+
+        RectInt32 toolbarBounds = target.GetInitialToolbarBounds(width: 345, height: 75, margin: 10);
+
+        Assert.Equal(110, toolbarBounds.X);
+        Assert.Equal(1015, toolbarBounds.Y);
+        Assert.Equal(345, toolbarBounds.Width);
+        Assert.Equal(75, toolbarBounds.Height);
+    }
 }

--- a/WindBoard.Tests/Features/ScreenAnnotation/ScreenAnnotationWindowInteropStyleTests.cs
+++ b/WindBoard.Tests/Features/ScreenAnnotation/ScreenAnnotationWindowInteropStyleTests.cs
@@ -1,4 +1,6 @@
+using System.Runtime.InteropServices;
 using WindBoard.Features.ScreenAnnotation.Interop;
+using Windows.Graphics;
 using Xunit;
 
 namespace WindBoard.Tests.Features.ScreenAnnotation;
@@ -68,5 +70,54 @@ public sealed class ScreenAnnotationWindowInteropStyleTests
     {
         Assert.Equal(33u, ScreenAnnotationWindowInterop.DwmWindowCornerPreferenceAttribute);
         Assert.Equal(1u, ScreenAnnotationWindowInterop.DwmWindowCornerPreferenceDoNotRound);
+    }
+
+    [Fact]
+    public void ConvertDipSizeToPixels_ScalesToolbarSizeUsingWindowDpi()
+    {
+        Assert.Equal(345, ScreenAnnotationWindowInterop.ConvertDipSizeToPixels(276, 120));
+        Assert.Equal(75, ScreenAnnotationWindowInterop.ConvertDipSizeToPixels(60, 120));
+    }
+
+    [Fact]
+    public void ConvertDipCoordinateToPixels_ScalesToolbarMarginUsingWindowDpi()
+    {
+        Assert.Equal(10, ScreenAnnotationWindowInterop.ConvertDipCoordinateToPixels(8, 120));
+    }
+
+    [Fact]
+    public void ConvertDpiToScaleRatio_UsesNinetySixDpiAsBase()
+    {
+        Assert.Equal(1.25, ScreenAnnotationWindowInterop.ConvertDpiToScaleRatio(120), precision: 2);
+        Assert.Equal(1.50, ScreenAnnotationWindowInterop.ConvertDpiToScaleRatio(144), precision: 2);
+    }
+
+    [Fact]
+    public void ConvertDpiToScalePercent_RoundsToNearestIntegerPercent()
+    {
+        Assert.Equal(125, ScreenAnnotationWindowInterop.ConvertDpiToScalePercent(120));
+        Assert.Equal(150, ScreenAnnotationWindowInterop.ConvertDpiToScalePercent(144));
+    }
+
+    [Fact]
+    public void TryReadDpiChangedSuggestedRect_ReadsSuggestedWindowBounds()
+    {
+        nint buffer = Marshal.AllocHGlobal(sizeof(int) * 4);
+        try
+        {
+            Marshal.WriteInt32(buffer, 0, 120);
+            Marshal.WriteInt32(buffer, sizeof(int), 220);
+            Marshal.WriteInt32(buffer, sizeof(int) * 2, 420);
+            Marshal.WriteInt32(buffer, sizeof(int) * 3, 295);
+
+            bool ok = ScreenAnnotationWindowInterop.TryReadDpiChangedSuggestedRect(buffer, out RectInt32 rect);
+
+            Assert.True(ok);
+            Assert.Equal(new RectInt32(120, 220, 300, 75), rect);
+        }
+        finally
+        {
+            Marshal.FreeHGlobal(buffer);
+        }
     }
 }

--- a/WindBoard/App.xaml.cs
+++ b/WindBoard/App.xaml.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Runtime.InteropServices;
 using System.Runtime.InteropServices.WindowsRuntime;
 using System.Threading.Tasks;
 using Microsoft.UI.Xaml;
@@ -17,6 +18,7 @@ using Windows.ApplicationModel.Activation;
 using Windows.Foundation;
 using Windows.Foundation.Collections;
 using WindBoard.Errors;
+using WindBoard.Features.ScreenAnnotation.Interop;
 using WindBoard.Fonts;
 using WindBoard.Logging;
 using WindBoard.Localization;
@@ -147,6 +149,7 @@ namespace WindBoard
             AppLog.Info("App", $"应用启动：version={version}, args='{args.Arguments ?? string.Empty}', logFile='{AppLog.CurrentLogFilePath ?? "(null)"}'");
 
             _window = new MainWindow();
+            LogStartupEnvironmentInfo(_window);
             _window.Activate();
 
             try
@@ -189,6 +192,29 @@ namespace WindBoard
                 // 提醒失败不应影响启动：记录日志便于排查。
                 AppLog.Warn("Reminders", "启动阶段数据目录提醒失败", ex);
             }
+        }
+
+        private static void LogStartupEnvironmentInfo(Window window)
+        {
+            string osDescription = RuntimeInformation.OSDescription;
+            IntPtr hwnd = WinRT.Interop.WindowNative.GetWindowHandle(window);
+            if (hwnd == IntPtr.Zero)
+            {
+                AppLog.Warn("App.Environment", $"启动阶段读取环境信息失败：system='{osDescription}', reason='window-handle-zero'");
+                return;
+            }
+
+            if (!ScreenAnnotationWindowInterop.TryGetWindowDpi(hwnd, out uint dpi, out string? error))
+            {
+                AppLog.Warn("App.Environment", $"启动阶段读取环境信息失败：system='{osDescription}', error='{error}'");
+                return;
+            }
+
+            double scaleRatio = ScreenAnnotationWindowInterop.ConvertDpiToScaleRatio(dpi);
+            int scalePercent = ScreenAnnotationWindowInterop.ConvertDpiToScalePercent(dpi);
+            AppLog.Info(
+                "App.Environment",
+                $"启动环境：system='{osDescription}', dpi={dpi}, scaleRatio={scaleRatio:F2}, scalePercent={scalePercent}%");
         }
 
         private static void EnsureAppNotificationInvokedHandlerHooked()

--- a/WindBoard/Features/ScreenAnnotation/Interop/ScreenAnnotationWindowInterop.cs
+++ b/WindBoard/Features/ScreenAnnotation/Interop/ScreenAnnotationWindowInterop.cs
@@ -33,9 +33,11 @@ namespace WindBoard.Features.ScreenAnnotation.Interop
         private const int SwRestore = 9;
         private const int SwShow = 5;
         private const int EInvalidArg = unchecked((int)0x80070057);
+        private const uint UserDefaultScreenDpi = 96;
 
         private const uint LwaAlpha = 0x00000002;
         private const uint MonitorDefaultToNearest = 2;
+        internal const uint WmDpiChanged = 0x02E0;
         internal const uint DwmWindowCornerPreferenceAttribute = 33;
         internal const uint DwmBorderColorAttribute = 34;
         internal const uint DwmWindowCornerPreferenceDoNotRound = 1;
@@ -230,6 +232,61 @@ namespace WindBoard.Features.ScreenAnnotation.Interop
             return BuildUpdatedStyle(currentStyle, WsExToolWindow | WsExLayered, removeFlags: 0);
         }
 
+        /// <summary>
+        /// 将 XAML 使用的有效像素坐标转换为窗口互操作所需的物理像素坐标。
+        /// </summary>
+        internal static int ConvertDipCoordinateToPixels(double value, uint dpi)
+        {
+            return (int)Math.Round(value * dpi / UserDefaultScreenDpi, MidpointRounding.AwayFromZero);
+        }
+
+        /// <summary>
+        /// 将 XAML 使用的有效像素尺寸转换为窗口互操作所需的物理像素尺寸。
+        /// 对尺寸使用向上取整，避免高 DPI 下出现 1px 裁切。
+        /// </summary>
+        internal static int ConvertDipSizeToPixels(double value, uint dpi)
+        {
+            return (int)Math.Ceiling(value * dpi / UserDefaultScreenDpi);
+        }
+
+        /// <summary>
+        /// 把窗口 DPI 转换为相对 96 DPI 基准的缩放倍数。
+        /// </summary>
+        internal static double ConvertDpiToScaleRatio(uint dpi)
+        {
+            uint safeDpi = dpi == 0 ? UserDefaultScreenDpi : dpi;
+            return safeDpi / (double)UserDefaultScreenDpi;
+        }
+
+        /// <summary>
+        /// 把窗口 DPI 转换为常见日志使用的百分比缩放值。
+        /// </summary>
+        internal static int ConvertDpiToScalePercent(uint dpi)
+        {
+            return (int)Math.Round(ConvertDpiToScaleRatio(dpi) * 100, MidpointRounding.AwayFromZero);
+        }
+
+        internal static bool TryGetWindowDpi(IntPtr hwnd, out uint dpi, out string? error)
+        {
+            dpi = 0;
+
+            if (hwnd == IntPtr.Zero)
+            {
+                error = "Window handle is zero.";
+                return false;
+            }
+
+            dpi = GetDpiForWindow(hwnd);
+            if (dpi == 0)
+            {
+                error = $"GetDpiForWindow failed: lastError={Marshal.GetLastWin32Error()}";
+                return false;
+            }
+
+            error = null;
+            return true;
+        }
+
         internal static bool TryMinimizeWindow(IntPtr hwnd, out string? error)
         {
             if (hwnd == IntPtr.Zero)
@@ -347,6 +404,45 @@ namespace WindBoard.Features.ScreenAnnotation.Interop
             WindowPos windowPos = Marshal.PtrToStructure<WindowPos>((IntPtr)lParam);
             insertAfterHwnd = windowPos.InsertAfter;
             flags = windowPos.Flags;
+            return true;
+        }
+
+        internal static bool TryReadDpiChangedSuggestedRect(nint lParam, out RectInt32 rect)
+        {
+            rect = default;
+
+            if (lParam == 0)
+            {
+                return false;
+            }
+
+            Rect nativeRect = Marshal.PtrToStructure<Rect>((IntPtr)lParam);
+            rect = ToRectInt32(nativeRect);
+            return true;
+        }
+
+        internal static bool TryMoveAndResizeWindow(IntPtr hwnd, RectInt32 bounds, out string? error)
+        {
+            if (hwnd == IntPtr.Zero)
+            {
+                error = "Window handle is zero.";
+                return false;
+            }
+
+            if (!SetWindowPos(
+                hwnd,
+                IntPtr.Zero,
+                bounds.X,
+                bounds.Y,
+                bounds.Width,
+                bounds.Height,
+                SwpNoZOrder | SwpNoActivate | SwpShowWindow))
+            {
+                error = $"SetWindowPos(move and resize) failed: lastError={Marshal.GetLastWin32Error()}";
+                return false;
+            }
+
+            error = null;
             return true;
         }
 
@@ -528,6 +624,9 @@ namespace WindBoard.Features.ScreenAnnotation.Interop
 
         [DllImport("user32.dll", SetLastError = true)]
         private static extern bool GetWindowRect(IntPtr hwnd, out Rect rect);
+
+        [DllImport("user32.dll", SetLastError = true)]
+        private static extern uint GetDpiForWindow(IntPtr hwnd);
 
         [DllImport("user32.dll", SetLastError = true)]
         private static extern nint MonitorFromWindow(IntPtr hwnd, uint dwFlags);

--- a/WindBoard/Features/ScreenAnnotation/Models/ScreenAnnotationDisplayTarget.cs
+++ b/WindBoard/Features/ScreenAnnotation/Models/ScreenAnnotationDisplayTarget.cs
@@ -11,7 +11,7 @@ namespace WindBoard.Features.ScreenAnnotation.Models
         RectInt32 Bounds,
         RectInt32 WorkArea)
     {
-        private const int DefaultToolbarMargin = 8;
+        internal const int DefaultToolbarMargin = 8;
 
         /// <summary>
         /// 计算工具栏默认位置。
@@ -21,25 +21,45 @@ namespace WindBoard.Features.ScreenAnnotation.Models
         /// - 优先放在工作区左下角；
         /// - 若工具栏尺寸大于工作区，则钳制到工作区内，避免初始位置跑出屏幕。
         /// </remarks>
-        internal RectInt32 GetInitialToolbarBounds(int width, int height)
+        internal RectInt32 GetInitialToolbarBounds(int width, int height, int margin = DefaultToolbarMargin)
         {
-            RectInt32 area = WorkArea.Width > 0 && WorkArea.Height > 0 ? WorkArea : Bounds;
+            RectInt32 area = GetVisibleArea();
+            int safeMargin = Math.Max(0, margin);
             int toolbarWidth = Math.Clamp(width, 1, Math.Max(1, area.Width));
             int toolbarHeight = Math.Clamp(height, 1, Math.Max(1, area.Height));
 
-            int minX = area.X;
-            int maxX = area.X + Math.Max(0, area.Width - toolbarWidth);
-            int minY = area.Y;
-            int maxY = area.Y + Math.Max(0, area.Height - toolbarHeight);
+            return ClampBoundsToVisibleArea(
+                new RectInt32(
+                    area.X + safeMargin,
+                    area.Y + area.Height - toolbarHeight - safeMargin,
+                    toolbarWidth,
+                    toolbarHeight));
+        }
 
-            int preferredX = area.X + DefaultToolbarMargin;
-            int preferredY = area.Y + area.Height - toolbarHeight - DefaultToolbarMargin;
+        /// <summary>
+        /// 把任意窗口矩形钳制到当前显示器可见工作区内。
+        /// </summary>
+        internal RectInt32 ClampBoundsToVisibleArea(RectInt32 bounds)
+        {
+            RectInt32 area = GetVisibleArea();
+            int width = Math.Clamp(bounds.Width, 1, Math.Max(1, area.Width));
+            int height = Math.Clamp(bounds.Height, 1, Math.Max(1, area.Height));
+
+            int minX = area.X;
+            int maxX = area.X + Math.Max(0, area.Width - width);
+            int minY = area.Y;
+            int maxY = area.Y + Math.Max(0, area.Height - height);
 
             return new RectInt32(
-                Math.Clamp(preferredX, minX, maxX),
-                Math.Clamp(preferredY, minY, maxY),
-                toolbarWidth,
-                toolbarHeight);
+                Math.Clamp(bounds.X, minX, maxX),
+                Math.Clamp(bounds.Y, minY, maxY),
+                width,
+                height);
+        }
+
+        private RectInt32 GetVisibleArea()
+        {
+            return WorkArea.Width > 0 && WorkArea.Height > 0 ? WorkArea : Bounds;
         }
     }
 }

--- a/WindBoard/Features/ScreenAnnotation/Services/ScreenAnnotationFlow.cs
+++ b/WindBoard/Features/ScreenAnnotation/Services/ScreenAnnotationFlow.cs
@@ -375,5 +375,6 @@ namespace WindBoard.Features.ScreenAnnotation.Services
                 AppLog.Warn("ScreenAnnotation", $"关闭桌面批注窗口失败：name={name}", ex);
             }
         }
+
     }
 }

--- a/WindBoard/Features/ScreenAnnotation/UI/ScreenAnnotationToolbarWindow.xaml.cs
+++ b/WindBoard/Features/ScreenAnnotation/UI/ScreenAnnotationToolbarWindow.xaml.cs
@@ -23,11 +23,12 @@ namespace WindBoard.Features.ScreenAnnotation.UI
     /// </summary>
     public sealed partial class ScreenAnnotationToolbarWindow : Window, IScreenAnnotationModeToolbar
     {
-        private const int ExpandedToolbarWidth = 276;
-        private const int ToolbarHeight = 60;
+        private const double ExpandedToolbarWidthDip = 276;
+        private const double ToolbarHeightDip = 60;
         private const double ClearCanvasSlideThumbInset = 6.0;
         private const double ClearCanvasSlideCompleteRatio = 0.90;
         private const int ClearCanvasSlideResetAnimationMs = 160;
+        private const uint DefaultWindowDpi = 96;
 
         private readonly ScreenAnnotationDisplayTarget _displayTarget;
         private ScreenAnnotationTransparentBackdrop? _transparentBackdrop;
@@ -160,7 +161,7 @@ namespace WindBoard.Features.ScreenAnnotation.UI
                 return;
             }
 
-            RectInt32 bounds = _displayTarget.GetInitialToolbarBounds(width: ExpandedToolbarWidth, height: ToolbarHeight);
+            RectInt32 bounds = BuildInitialToolbarBounds(hwnd);
             if (!ScreenAnnotationWindowInterop.TryConfigureBorderlessWindow(appWindow, bounds, out string? windowError))
             {
                 AppLog.Warn("ScreenAnnotation.Interop", $"配置工具栏窗口失败：error='{windowError}'");
@@ -547,6 +548,28 @@ namespace WindBoard.Features.ScreenAnnotation.UI
             ReturnToAppRequested?.Invoke(this, EventArgs.Empty);
         }
 
+        private RectInt32 BuildInitialToolbarBounds(IntPtr hwnd)
+        {
+            // 工具栏 XAML 按有效像素设计，但顶层 AppWindow 需要物理像素矩形；
+            // 这里统一按窗口当前 DPI 把设计尺寸转换后再交给原生窗口。
+            uint dpi = ResolveWindowDpi(hwnd);
+            int width = ScreenAnnotationWindowInterop.ConvertDipSizeToPixels(ExpandedToolbarWidthDip, dpi);
+            int height = ScreenAnnotationWindowInterop.ConvertDipSizeToPixels(ToolbarHeightDip, dpi);
+            int margin = ScreenAnnotationWindowInterop.ConvertDipCoordinateToPixels(ScreenAnnotationDisplayTarget.DefaultToolbarMargin, dpi);
+            return _displayTarget.GetInitialToolbarBounds(width, height, margin);
+        }
+
+        private uint ResolveWindowDpi(IntPtr hwnd)
+        {
+            if (ScreenAnnotationWindowInterop.TryGetWindowDpi(hwnd, out uint dpi, out string? error))
+            {
+                return dpi;
+            }
+
+            AppLog.Warn("ScreenAnnotation.Interop", $"读取工具栏窗口 DPI 失败，将回退到默认 DPI：error='{error}'");
+            return DefaultWindowDpi;
+        }
+
         private void OnClearCanvasThumbPointerPressed(object sender, PointerRoutedEventArgs e)
         {
             if (!_isClearCanvasSlideEnabled || ClearCanvasSlideThumbTransform is null || ClearCanvasSlideHost is null)
@@ -760,12 +783,18 @@ namespace WindBoard.Features.ScreenAnnotation.UI
                 return;
             }
 
+            IntPtr hwnd = ScreenAnnotationWindowInterop.GetWindowHandle(this);
+            if (!ScreenAnnotationWindowInterop.TryGetWindowRect(hwnd, out RectInt32 currentWindowBounds))
+            {
+                return;
+            }
+
             RectInt32 area = _displayTarget.WorkArea.Width > 0 && _displayTarget.WorkArea.Height > 0
                 ? _displayTarget.WorkArea
                 : _displayTarget.Bounds;
 
-            int maxX = area.X + Math.Max(0, area.Width - appWindow.Size.Width);
-            int maxY = area.Y + Math.Max(0, area.Height - appWindow.Size.Height);
+            int maxX = area.X + Math.Max(0, area.Width - currentWindowBounds.Width);
+            int maxY = area.Y + Math.Max(0, area.Height - currentWindowBounds.Height);
 
             int newX = Math.Clamp(_dragStartWindowOrigin.X + deltaX, area.X, maxX);
             int newY = Math.Clamp(_dragStartWindowOrigin.Y + deltaY, area.Y, maxY);
@@ -819,6 +848,30 @@ namespace WindBoard.Features.ScreenAnnotation.UI
             ToolButtonsPanel.Visibility = _isCollapsed ? Visibility.Collapsed : Visibility.Visible;
         }
 
+        private void OnBackdropWindowMessageObserved(object? sender, ScreenAnnotationWindowMessageEventArgs e)
+        {
+            if (!_isWindowInitialized || e.MessageId != ScreenAnnotationWindowInterop.WmDpiChanged)
+            {
+                return;
+            }
+
+            if (!ScreenAnnotationWindowInterop.TryReadDpiChangedSuggestedRect(e.LParam, out RectInt32 suggestedBounds))
+            {
+                AppLog.Warn("ScreenAnnotation.Interop", "读取工具栏 DPI 变化建议矩形失败。");
+                return;
+            }
+
+            RectInt32 clampedBounds = _displayTarget.ClampBoundsToVisibleArea(suggestedBounds);
+            if (!ScreenAnnotationWindowInterop.TryMoveAndResizeWindow(e.Hwnd, clampedBounds, out string? error))
+            {
+                AppLog.Warn("ScreenAnnotation.Interop", $"处理工具栏 DPI 变化失败：error='{error}'");
+                return;
+            }
+
+            e.Result = IntPtr.Zero;
+            e.Handled = true;
+        }
+
         private bool TryAttachTransparentBackdrop(IntPtr hwnd, out string? error)
         {
             if (_transparentBackdrop is not null)
@@ -831,6 +884,7 @@ namespace WindBoard.Features.ScreenAnnotation.UI
             {
                 // 工具栏也需要挂透明 backdrop，否则即便 XAML 根节点透明，WinUI 顶层窗口仍可能退化成黑底。
                 var backdrop = new ScreenAnnotationTransparentBackdrop(hwnd);
+                backdrop.WindowMessageObserved += OnBackdropWindowMessageObserved;
                 SystemBackdrop = backdrop;
                 _transparentBackdrop = backdrop;
                 error = null;
@@ -845,6 +899,11 @@ namespace WindBoard.Features.ScreenAnnotation.UI
 
         private void OnWindowClosed(object sender, WindowEventArgs args)
         {
+            if (_transparentBackdrop is not null)
+            {
+                _transparentBackdrop.WindowMessageObserved -= OnBackdropWindowMessageObserved;
+            }
+
             SystemBackdrop = null;
             _transparentBackdrop = null;
         }

--- a/WindBoard/Features/Shortcuts/UI/ShortcutsSettingsPage.xaml
+++ b/WindBoard/Features/Shortcuts/UI/ShortcutsSettingsPage.xaml
@@ -94,7 +94,8 @@
                     <StackPanel Spacing="12">
                         <controls:SettingsCard Header="{l10n:Loc Key=Settings_Shortcuts_Mouse_PanViewport_Title}">
                             <controls:SettingsCard.HeaderIcon>
-                                <SymbolIcon Symbol="TouchPointer" />
+                                <!-- 平移视口：使用“地图/平移”语义图标 -->
+                                <SymbolIcon Symbol="Map" />
                             </controls:SettingsCard.HeaderIcon>
                             <controls:SettingsCard.Content>
                                 <TextBlock
@@ -106,7 +107,8 @@
 
                         <controls:SettingsCard Header="{l10n:Loc Key=Settings_Shortcuts_Mouse_ZoomViewport_Title}">
                             <controls:SettingsCard.HeaderIcon>
-                                <SymbolIcon Symbol="TouchPointer" />
+                                <!-- 缩放视口：使用通用缩放图标 -->
+                                <SymbolIcon Symbol="Zoom" />
                             </controls:SettingsCard.HeaderIcon>
                             <controls:SettingsCard.Content>
                                 <TextBlock
@@ -118,7 +120,8 @@
 
                         <controls:SettingsCard Header="{l10n:Loc Key=Settings_Shortcuts_Mouse_ZoomSelection_Title}">
                             <controls:SettingsCard.HeaderIcon>
-                                <SymbolIcon Symbol="TouchPointer" />
+                                <!-- 缩放选区：改用兼容性更稳的“框选区域”语义图标 -->
+                                <SymbolIcon Symbol="Crop" />
                             </controls:SettingsCard.HeaderIcon>
                             <controls:SettingsCard.Content>
                                 <TextBlock
@@ -130,7 +133,8 @@
 
                         <controls:SettingsCard Header="{l10n:Loc Key=Settings_Shortcuts_Mouse_RotateSelection_Title}">
                             <controls:SettingsCard.HeaderIcon>
-                                <SymbolIcon Symbol="TouchPointer" />
+                                <!-- 旋转选区：使用旋转语义图标 -->
+                                <SymbolIcon Symbol="Rotate" />
                             </controls:SettingsCard.HeaderIcon>
                             <controls:SettingsCard.Content>
                                 <TextBlock

--- a/WindBoard/Settings/Pages/AppearanceSettingsPage.xaml
+++ b/WindBoard/Settings/Pages/AppearanceSettingsPage.xaml
@@ -109,11 +109,8 @@
                         Header="{l10n:Loc Key=Settings_Appearance_ElementCardTheme_Title}"
                         Description="{l10n:Loc Key=Settings_Appearance_ElementCardTheme_Description}">
                     <controls:SettingsCard.HeaderIcon>
-                        <!-- 图标字体：Color -->
-                        <FontIcon
-                            FontFamily="{ThemeResource SymbolThemeFontFamily}"
-                            FontSize="16"
-                            Glyph="&#xE790;" />
+                        <!-- 元素卡片主题：改用“预览”语义图标，避免与背景颜色重复 -->
+                        <SymbolIcon Symbol="Preview" />
                     </controls:SettingsCard.HeaderIcon>
                     <controls:SettingsCard.Content>
                         <TextBlock

--- a/WindBoard/Settings/Pages/WritingSettingsPage.xaml
+++ b/WindBoard/Settings/Pages/WritingSettingsPage.xaml
@@ -21,8 +21,8 @@
                     Header="{l10n:Loc Key=Settings_Pen_Title}"
                     Description="{l10n:Loc Key=Settings_Writing_Pen_Description}">
                     <controls:SettingsCard.HeaderIcon>
-                        <!-- 画笔设置：用“设置”图标与左侧导航项区分 -->
-                        <SymbolIcon Symbol="Setting" />
+                        <!-- 画笔设置：改用更贴近书写语义的高亮笔图标 -->
+                        <SymbolIcon Symbol="Highlight" />
                     </controls:SettingsCard.HeaderIcon>
                 </controls:SettingsCard>
             </StackPanel>


### PR DESCRIPTION
## Summary by Sourcery

在高 DPI 环境下改进屏幕标注工具栏行为，并记录启动时的 DPI/缩放信息。

Bug 修复：
- 修复屏幕标注工具栏的尺寸、边距和拖动边界计算，使其遵循每个窗口的 DPI 设置，避免在缩放显示器上出现裁剪问题。
- 处理标注工具栏的 `WM_DPICHANGED` 消息，使其在显示器 DPI 发生变化时，能够在可见工作区内移动和调整大小。

增强功能：
- 添加在 XAML DIPs、物理像素与基于 DPI 的缩放比例之间转换的辅助函数，并在各屏幕标注组件中复用。
- 为 `ScreenAnnotationDisplayTarget` 增加边距配置，以及将窗口边界泛化地限制在可见工作区内的能力。
- 在应用启动时记录操作系统描述以及主窗口的有效 DPI/缩放比例，以便诊断问题。

测试：
- 新增单元测试，覆盖 DPI 转换辅助函数、`WM_DPICHANGED` 建议矩形解析，以及带自定义边距的工具栏边界计算。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve screen annotation toolbar behavior under high-DPI environments and log startup DPI/scale information.

Bug Fixes:
- Fix screen annotation toolbar size, margin, and drag bounds computation so they respect per-window DPI and avoid clipping on scaled displays.
- Handle WM_DPICHANGED for the annotation toolbar to move and resize within the visible work area when display DPI changes.

Enhancements:
- Add helpers for converting between XAML DIPs, physical pixels, and DPI-based scale ratios, and reuse them across screen annotation components.
- Extend ScreenAnnotationDisplayTarget with margin configuration and generic clamping of window bounds to the visible work area.
- Log OS description and effective DPI/scale of the main window at app startup for diagnostics.

Tests:
- Add unit tests covering DPI conversion helpers, WM_DPICHANGED suggested-rect parsing, and toolbar bounds calculation with custom margins.

</details>