### PR TITLE
统一设置页设计

### DIFF
--- a/.trellis/spec/frontend/component-guidelines.md
+++ b/.trellis/spec/frontend/component-guidelines.md
@@ -124,8 +124,8 @@ xmlns:l10n="using:WindBoard.Localization"
 
 <TextBlock Text="{l10n:Loc Key=Settings_Dock_Title}" />
 <Button Content="{l10n:Loc Key=Common_SelectEllipsis}" />
-<ContentDialog Title="{l10n:Loc Key=ImportDialog_Title}"
-               PrimaryButtonText="{l10n:Loc Key=Common_Import}" />
+<ContentDialog Title="{l10n:Loc Key=Common_ConfirmOverwrite_Title}"
+               PrimaryButtonText="{l10n:Loc Key=Common_Overwrite}" />
 <ToolTipService.ToolTip="{l10n:Loc Key=Some_Tooltip}" />
 ```
 
@@ -136,7 +136,7 @@ L10n.Get("Common_BringToFront")
 L10n.Format("Settings_Camouflage_CreateShortcut_Success_Fmt", shortcutPath)
 ```
 
-**Key 命名约定**：`功能域_子项`（如 `Settings_Dock_Title`、`Common_Delete`、`ImportDialog_Queue_Title`）
+**Key 命名约定**：`功能域_子项`（如 `Settings_Dock_Title`、`Common_Delete`、`Import_Failed_Title`）
 
 ---
 

--- a/.trellis/spec/frontend/component-guidelines.md
+++ b/.trellis/spec/frontend/component-guidelines.md
@@ -183,6 +183,54 @@ L10n.Format("Settings_Camouflage_CreateShortcut_Success_Fmt", shortcutPath)
     PaneToggleRequested="OnTitleBarPaneToggleRequested" />
 ```
 
+### Convention: 设置页共享 ResourceDictionary
+
+**What**：当多个设置页需要复用同一套间距、Padding、卡片网格节奏时，把常量和基础容器样式放到 `WindBoard/Settings/SettingsPageResources.xaml`，并由 `WindBoard/App.xaml` 的 `MergedDictionaries` 统一合并。
+
+**Why**：设置页常量散落在各个 XAML 页面里时，一次视觉收敛会演变成多文件批量修改，容易漏改并造成密度漂移。共享 ResourceDictionary 可以把“单一视觉决策”收敛成单点配置。
+
+**Current contract**：
+
+- 资源文件路径：`WindBoard/Settings/SettingsPageResources.xaml`
+- 合并入口：`WindBoard/App.xaml`
+- 当前共享键：`SettingsCardGroupSpacing`、`SettingsPagePadding`
+- 当前共享样式：`SettingsPageRootStackPanelStyle`、`SettingsPageSectionStackPanelStyle`、`SettingsPageCardGridStyle`
+
+**Use when**：
+
+- 3 个及以上设置页需要同一视觉常量
+- 复用的是布局节奏，不是单页私有表单排版
+- 目标容器是设置页根 `StackPanel`、分组 `StackPanel` 或卡片列表 `Grid`
+
+**Example**：
+
+```xaml
+<!-- WindBoard/App.xaml -->
+<ResourceDictionary.MergedDictionaries>
+    <XamlControlsResources xmlns="using:Microsoft.UI.Xaml.Controls" />
+    <ResourceDictionary Source="ms-appx:///Settings/SettingsPageResources.xaml" />
+</ResourceDictionary.MergedDictionaries>
+
+<!-- Settings page root -->
+<StackPanel Style="{StaticResource SettingsPageRootStackPanelStyle}">
+    <StackPanel Style="{StaticResource SettingsPageSectionStackPanelStyle}">
+        <TextBlock Style="{ThemeResource SubtitleTextBlockStyle}" Text="Section" />
+        <controls:SettingsCard Header="Example" />
+    </StackPanel>
+
+    <Grid Style="{StaticResource SettingsPageCardGridStyle}">
+        <controls:SettingsCard Header="Left" />
+        <controls:SettingsCard Grid.Column="1" Header="Right" />
+    </Grid>
+</StackPanel>
+```
+
+**Don't**：
+
+- 不要把单页私有的预览区、弹窗内容间距强行抽进这个字典
+- 不要为了一个页面或一个局部控件新建全局键
+- 不要在多个设置页里重复写 `Spacing="4" Padding="24"` 这一类共享布局常量
+
 ### 避免（来自 winui-app skill + deslop skill）
 
 - 散落的主题画刷和样式（应集中到 App.xaml 或共享 ResourceDictionary）

--- a/.trellis/spec/frontend/component-guidelines.md
+++ b/.trellis/spec/frontend/component-guidelines.md
@@ -146,15 +146,49 @@ L10n.Format("Settings_Camouflage_CreateShortcut_Success_Fmt", shortcutPath)
 
 - 使用原生 `CommandBar` 或其他标准 WinUI 命令表面，不自行发明工具栏
 - 优先组合/重样式内置 WinUI 控件，再考虑 CommunityToolkit，最后才自定义控件
+- 组件和 UI 交互优先使用原生 WinUI 实现，不要为按钮、返回按钮、侧边栏折叠按钮等常规控件做自绘替代
+- 当 `TitleBar`、`NavigationView`、`CommandBar`、`Button` 等原生控件已提供所需能力时，直接使用其内建能力，不在外层再包一层“仿原生”实现
 - 默认支持 Light/Dark 主题，使用主题感知资源和系统画刷
 - 使用 `x:Bind` 提升编译时安全性和性能
 - 保持简洁的可视化树，避免过深的 XAML 嵌套
+
+### 原生控件约定
+
+**What**：常规交互组件默认使用 WinUI 原生控件或其内建能力，不使用自绘去模拟已有系统控件。
+
+**Why**：原生控件能自动获得系统交互、主题、可访问性、标题栏集成和平台后续行为更新；自绘“仿原生”按钮容易在尺寸、边框、状态、焦点反馈和可访问性上与系统行为漂移。
+
+**Example**：
+
+```xaml
+<!-- Wrong: 原生 TitleBar 已有 BackButton/PaneToggleButton，仍自行塞入两个 Button 模拟 -->
+<TitleBar>
+    <TitleBar.LeftHeader>
+        <StackPanel Orientation="Horizontal">
+            <Button>
+                <SymbolIcon Symbol="Back" />
+            </Button>
+            <Button>
+                <FontIcon Glyph="&#xE700;" />
+            </Button>
+        </StackPanel>
+    </TitleBar.LeftHeader>
+</TitleBar>
+
+<!-- Correct: 使用 TitleBar 内建按钮，仅处理事件 -->
+<TitleBar
+    IsBackButtonVisible="True"
+    IsPaneToggleButtonVisible="True"
+    BackRequested="OnTitleBarBackRequested"
+    PaneToggleRequested="OnTitleBarPaneToggleRequested" />
+```
 
 ### 避免（来自 winui-app skill + deslop skill）
 
 - 散落的主题画刷和样式（应集中到 App.xaml 或共享 ResourceDictionary）
 - 不必要的 `Border` 包装（"双重卡片"反模式）
 - 硬编码颜色值（应使用主题资源）
+- 用自绘 `Button`、`Border`、`Path` 等去模拟已有原生控件的视觉与行为
 - 过度防御性检查（如在已验证的内部调用路径上加 null 检查）
 - AI 生成的多余注释（注释应解释"为什么"，而非重复代码含义）
 
@@ -168,6 +202,7 @@ L10n.Format("Settings_Camouflage_CreateShortcut_Success_Fmt", shortcutPath)
 - 硬编码用户可见字符串（必须使用 `{l10n:Loc Key=...}` 或 `L10n.Get()`)
 - 在 XAML 中使用 `Binding` 当 `x:Bind` 可用时
 - 忘记 `_isSyncingFromSettings` 防循环（设置页几乎都需要）
+- 在已有原生控件能力的场景下，用自绘组件替代系统按钮/标题栏按钮/导航按钮
 
 ### ✅ DO
 - 事件处理在 code-behind，业务逻辑在 Services
@@ -175,3 +210,4 @@ L10n.Format("Settings_Camouflage_CreateShortcut_Success_Fmt", shortcutPath)
 - 通过 `AppSettingsService.Instance.Update()` 修改设置
 - 新 Feature 遵循 Flow + Models + Services + UI 统一结构
 - 崩溃链路中的 UI 操作必须包裹在 try-catch 中
+- 先确认 WinUI 原生控件是否已满足需求，再决定是否需要重样式或引入额外控件

--- a/.trellis/spec/frontend/directory-structure.md
+++ b/.trellis/spec/frontend/directory-structure.md
@@ -59,8 +59,7 @@ WindBoard/
 │   │   ├── ImportFlow.cs
 │   │   ├── Models/
 │   │   ├── Services/
-│   │   └── UI/
-│   │       └── ImportDialog.xaml(.cs)  # ContentDialog
+│   │   └── UI/                         # 可选：仅在需要独立 XAML 页面/对话框时创建
 │   ├── ScreenAnnotation/
 │   │   ├── ScreenAnnotationFlow.cs
 │   │   ├── Services/
@@ -101,7 +100,7 @@ FeatureName/
 | 场景 | 基类 | 示例 |
 |------|------|------|
 | 设置页 | `Page` | `DockSettingsPage`、`CamouflageSettingsPage` |
-| 弹窗对话框 | `ContentDialog` | `ImportDialog` |
+| 弹窗对话框 | `ContentDialog` | `ImportFlow.ConfirmReplaceCurrentPageRiskAsync` |
 | 独立窗口 | `Window` | `ScreenAnnotationWindow` |
 
 ### MainWindow Partial 拆分
@@ -128,7 +127,7 @@ FeatureName/
 | 类型 | 约定 | 示例 |
 |------|------|------|
 | XAML 页面 | `{Feature}{Purpose}Page.xaml` | `DockSettingsPage.xaml` |
-| XAML 对话框 | `{Feature}Dialog.xaml` | `ImportDialog.xaml` |
+| XAML 对话框 | `{Feature}Dialog.xaml` | `（按需创建；当前导入流程无独立 XAML 对话框）` |
 | XAML 窗口 | `{Feature}Window.xaml` | `ScreenAnnotationWindow.xaml` |
 | Partial class | `{ClassName}.{Feature}.cs` | `MainWindow.Pages.cs` |
 | Flow 协调器 | `{Feature}Flow.cs` | `ExportFlow.cs` |

--- a/.trellis/spec/frontend/directory-structure.md
+++ b/.trellis/spec/frontend/directory-structure.md
@@ -71,7 +71,8 @@ WindBoard/
 │       ├── Services/
 │       └── UI/
 ├── Localization/                    # L10n 标记扩展 + 资源文件
-├── Settings/                        # AppSettingsService + AppSettingsStore
+├── Settings/                        # AppSettingsService、AppSettingsStore、设置页共享资源
+│   ├── SettingsPageResources.xaml   # 设置页共用间距/容器样式，App.xaml 合并后供各 Page 直接引用
 ├── Errors/                          # AppErrorService
 ├── Reminders/                       # AppReminderService
 ├── Updates/                         # AppUpdateService

--- a/.trellis/spec/frontend/quality-guidelines.md
+++ b/.trellis/spec/frontend/quality-guidelines.md
@@ -23,6 +23,7 @@ WindBoard 前端遵循"安全性 = 正确性 > 最小变更 > 可读性 > 一致
 
 - **硬编码颜色值**：必须使用主题感知资源和系统画刷（来自 winui-app skill）
 - **不必要的自定义控件**：优先组合/重样式内置 WinUI 控件（来自 winui-app skill）
+- **自绘仿原生组件**：已有原生 `Button`、`TitleBar`、`NavigationView`、`CommandBar` 等能力时，不要再用自绘方式模拟按钮、返回按钮、折叠按钮等系统交互
 - **双重卡片布局**：避免在已有卡片样式的子元素外再包 Border（来自 winui-app skill）
 - **嵌套 ScrollViewer 冲突**：外层页面已滚动时，嵌套 GridView 等需明确滚动归属（来自 winui-app skill）
 - **单主题输出**：默认支持 Light/Dark 模式（来自 winui-app skill）
@@ -50,6 +51,7 @@ WindBoard 前端遵循"安全性 = 正确性 > 最小变更 > 可读性 > 一致
 - **x:Bind 优先**：页面本地属性用 `x:Bind`，动态 DataContext 用 `Binding`
 - **原子写入**：设置保存使用临时文件替换策略
 - **防抖 Timer**：高频 UI 更新使用 DispatcherQueueTimer 做防抖
+- **原生优先**：先使用 WinUI 原生控件与内建交互能力，再考虑重样式，最后才考虑自定义/自绘实现
 
 ### 性能模式（来自 winui-app skill）
 
@@ -99,6 +101,7 @@ WindBoard 前端遵循"安全性 = 正确性 > 最小变更 > 可读性 > 一致
 
 - [ ] 无不必要的事件订阅泄漏（Dispose 中取消订阅）
 - [ ] 无过度 XAML 嵌套或不必要的 Border 包装
+- [ ] 常规交互按钮、标题栏按钮、导航按钮优先使用原生实现，无自绘仿原生替代
 - [ ] 设置页有 `_isSyncingFromSettings` 防循环
 - [ ] Feature 遵循 Flow + Models + Services + UI 结构
 

--- a/.trellis/workspace/Jerry-Z07/index.md
+++ b/.trellis/workspace/Jerry-Z07/index.md
@@ -8,7 +8,7 @@
 
 <!-- @@@auto:current-status -->
 - **Active File**: `journal-1.md`
-- **Total Sessions**: 4
+- **Total Sessions**: 5
 - **Last Active**: 2026-04-23
 <!-- @@@/auto:current-status -->
 
@@ -19,7 +19,7 @@
 <!-- @@@auto:active-documents -->
 | File | Lines | Status |
 |------|-------|--------|
-| `journal-1.md` | ~172 | Active |
+| `journal-1.md` | ~205 | Active |
 <!-- @@@/auto:active-documents -->
 
 ---
@@ -29,6 +29,7 @@
 <!-- @@@auto:session-history -->
 | # | Date | Title | Commits | Branch |
 |---|------|-------|---------|--------|
+| 5 | 2026-04-23 | 统一设置页 SettingsCard 布局资源 | `72a0ac0` | `develop` |
 | 4 | 2026-04-23 | 设置窗口标题栏原生化与设置搜索 | `e5a01d1` | `develop` |
 | 3 | 2026-04-22 | 移除导入窗口并改为直接文件选择器导入 | `6c52be0`, `af5c12d` | `develop` |
 | 2 | 2026-04-18 | 改进导入对话框文本与链接输入区 | `f8e9963` | `develop` |

--- a/.trellis/workspace/Jerry-Z07/index.md
+++ b/.trellis/workspace/Jerry-Z07/index.md
@@ -8,8 +8,8 @@
 
 <!-- @@@auto:current-status -->
 - **Active File**: `journal-1.md`
-- **Total Sessions**: 2
-- **Last Active**: 2026-04-18
+- **Total Sessions**: 3
+- **Last Active**: 2026-04-22
 <!-- @@@/auto:current-status -->
 
 ---
@@ -19,7 +19,7 @@
 <!-- @@@auto:active-documents -->
 | File | Lines | Status |
 |------|-------|--------|
-| `journal-1.md` | ~105 | Active |
+| `journal-1.md` | ~139 | Active |
 <!-- @@@/auto:active-documents -->
 
 ---
@@ -29,6 +29,7 @@
 <!-- @@@auto:session-history -->
 | # | Date | Title | Commits | Branch |
 |---|------|-------|---------|--------|
+| 3 | 2026-04-22 | 移除导入窗口并改为直接文件选择器导入 | `6c52be0`, `af5c12d` | `develop` |
 | 2 | 2026-04-18 | 改进导入对话框文本与链接输入区 | `f8e9963` | `develop` |
 | 1 | 2026-04-18 | 填充项目开发规范文档 | pending | `develop` |
 <!-- @@@/auto:session-history -->

--- a/.trellis/workspace/Jerry-Z07/index.md
+++ b/.trellis/workspace/Jerry-Z07/index.md
@@ -8,8 +8,8 @@
 
 <!-- @@@auto:current-status -->
 - **Active File**: `journal-1.md`
-- **Total Sessions**: 3
-- **Last Active**: 2026-04-22
+- **Total Sessions**: 4
+- **Last Active**: 2026-04-23
 <!-- @@@/auto:current-status -->
 
 ---
@@ -19,7 +19,7 @@
 <!-- @@@auto:active-documents -->
 | File | Lines | Status |
 |------|-------|--------|
-| `journal-1.md` | ~139 | Active |
+| `journal-1.md` | ~172 | Active |
 <!-- @@@/auto:active-documents -->
 
 ---
@@ -29,6 +29,7 @@
 <!-- @@@auto:session-history -->
 | # | Date | Title | Commits | Branch |
 |---|------|-------|---------|--------|
+| 4 | 2026-04-23 | 设置窗口标题栏原生化与设置搜索 | `e5a01d1` | `develop` |
 | 3 | 2026-04-22 | 移除导入窗口并改为直接文件选择器导入 | `6c52be0`, `af5c12d` | `develop` |
 | 2 | 2026-04-18 | 改进导入对话框文本与链接输入区 | `f8e9963` | `develop` |
 | 1 | 2026-04-18 | 填充项目开发规范文档 | pending | `develop` |

--- a/.trellis/workspace/Jerry-Z07/journal-1.md
+++ b/.trellis/workspace/Jerry-Z07/journal-1.md
@@ -170,3 +170,36 @@
 ### Next Steps
 
 - None - task complete
+
+
+## Session 5: 统一设置页 SettingsCard 布局资源
+
+**Date**: 2026-04-23
+**Task**: 统一设置页 SettingsCard 布局资源
+**Branch**: `develop`
+
+### Summary
+
+将设置页 SettingsCard 间距统一为 4，抽取 SettingsPageResources 共享资源，并同步前端 spec 约定。
+
+### Main Changes
+
+(Add details)
+
+### Git Commits
+
+| Hash | Message |
+|------|---------|
+| `72a0ac0` | (see git log) |
+
+### Testing
+
+- [OK] (Add test results)
+
+### Status
+
+[OK] **Completed**
+
+### Next Steps
+
+- None - task complete

--- a/.trellis/workspace/Jerry-Z07/journal-1.md
+++ b/.trellis/workspace/Jerry-Z07/journal-1.md
@@ -137,3 +137,36 @@
 ### Next Steps
 
 - None - task complete
+
+
+## Session 4: 设置窗口标题栏原生化与设置搜索
+
+**Date**: 2026-04-23
+**Task**: 设置窗口标题栏原生化与设置搜索
+**Branch**: `develop`
+
+### Summary
+
+重构设置窗口，使用原生 TitleBar 和 NavigationView 集成侧边栏折叠、返回导航与设置搜索；移除自绘仿原生按钮，清理相关文案，并同步更新 .trellis/spec/frontend，明确组件与 UI 优先使用原生 WinUI 实现。验证通过 dotnet build WindBoard.slnx -c Release 与 dotnet test WindBoard.slnx -c Release。
+
+### Main Changes
+
+(Add details)
+
+### Git Commits
+
+| Hash | Message |
+|------|---------|
+| `e5a01d1` | (see git log) |
+
+### Testing
+
+- [OK] (Add test results)
+
+### Status
+
+[OK] **Completed**
+
+### Next Steps
+
+- None - task complete

--- a/.trellis/workspace/Jerry-Z07/journal-1.md
+++ b/.trellis/workspace/Jerry-Z07/journal-1.md
@@ -103,3 +103,37 @@
 ### Next Steps
 
 - None - task complete
+
+
+## Session 3: 移除导入窗口并改为直接文件选择器导入
+
+**Date**: 2026-04-22
+**Task**: 移除导入窗口并改为直接文件选择器导入
+**Branch**: `develop`
+
+### Summary
+
+移除 ImportDialog、ImportQueueState 与工作区预览服务，导入入口改为 FileOpenPicker 直导；同步 .trellis/spec/frontend 文档，删除过时 ImportDialog 结构与示例。
+
+### Main Changes
+
+(Add details)
+
+### Git Commits
+
+| Hash | Message |
+|------|---------|
+| `6c52be0` | (see git log) |
+| `af5c12d` | (see git log) |
+
+### Testing
+
+- [OK] (Add test results)
+
+### Status
+
+[OK] **Completed**
+
+### Next Steps
+
+- None - task complete

--- a/WindBoard/App.xaml
+++ b/WindBoard/App.xaml
@@ -8,6 +8,7 @@
         <ResourceDictionary>
             <ResourceDictionary.MergedDictionaries>
                 <XamlControlsResources xmlns="using:Microsoft.UI.Xaml.Controls" />
+                <ResourceDictionary Source="ms-appx:///Settings/SettingsPageResources.xaml" />
                 <!-- Other merged dictionaries here -->
             </ResourceDictionary.MergedDictionaries>
 

--- a/WindBoard/Features/Camouflage/UI/CamouflageSettingsPage.xaml
+++ b/WindBoard/Features/Camouflage/UI/CamouflageSettingsPage.xaml
@@ -11,7 +11,7 @@
 
         <Grid>
         <ScrollViewer>
-            <StackPanel Spacing="4" Padding="24">
+            <StackPanel Style="{StaticResource SettingsPageRootStackPanelStyle}">
                 <TextBlock Text="{l10n:Loc Key=Settings_Camouflage_Description}" Opacity="0.75" TextWrapping="WrapWholeWords" />
 
                 <controls:SettingsCard Header="{l10n:Loc Key=Settings_Camouflage_Enabled_Header}">
@@ -24,7 +24,7 @@
                 </controls:SettingsCard>
 
                 <!-- 伪装未启用时，隐藏下方选项，避免误解为“已生效”。 -->
-                <StackPanel x:Name="OptionsPanel" Spacing="4" Visibility="Collapsed">
+                <StackPanel x:Name="OptionsPanel" Style="{StaticResource SettingsPageSectionStackPanelStyle}" Visibility="Collapsed">
                     <controls:SettingsCard
                         Header="{l10n:Loc Key=Settings_Camouflage_WindowTitle_Header}">
                         <controls:SettingsCard.Content>

--- a/WindBoard/Features/Camouflage/UI/CamouflageSettingsPage.xaml
+++ b/WindBoard/Features/Camouflage/UI/CamouflageSettingsPage.xaml
@@ -11,7 +11,7 @@
 
         <Grid>
         <ScrollViewer>
-            <StackPanel Spacing="16" Padding="24">
+            <StackPanel Spacing="4" Padding="24">
                 <TextBlock Text="{l10n:Loc Key=Settings_Camouflage_Description}" Opacity="0.75" TextWrapping="WrapWholeWords" />
 
                 <controls:SettingsCard Header="{l10n:Loc Key=Settings_Camouflage_Enabled_Header}">
@@ -24,11 +24,9 @@
                 </controls:SettingsCard>
 
                 <!-- 伪装未启用时，隐藏下方选项，避免误解为“已生效”。 -->
-                <StackPanel x:Name="OptionsPanel" Spacing="16" Visibility="Collapsed">
+                <StackPanel x:Name="OptionsPanel" Spacing="4" Visibility="Collapsed">
                     <controls:SettingsCard
-                        Header="{l10n:Loc Key=Settings_Camouflage_WindowTitle_Header}"
-                        ContentAlignment="Vertical"
-                        HorizontalContentAlignment="Stretch">
+                        Header="{l10n:Loc Key=Settings_Camouflage_WindowTitle_Header}">
                         <controls:SettingsCard.Content>
                             <TextBox
                                 x:Name="TitleTextBox"
@@ -39,9 +37,7 @@
                     </controls:SettingsCard>
 
                     <controls:SettingsCard
-                        Header="{l10n:Loc Key=Settings_Camouflage_Icon_Header}"
-                        ContentAlignment="Vertical"
-                        HorizontalContentAlignment="Stretch">
+                        Header="{l10n:Loc Key=Settings_Camouflage_Icon_Header}">
                         <StackPanel Spacing="8">
                             <Grid ColumnDefinitions="*,Auto,Auto" ColumnSpacing="8">
                                 <TextBox

--- a/WindBoard/Features/Camouflage/UI/CamouflageSettingsPage.xaml
+++ b/WindBoard/Features/Camouflage/UI/CamouflageSettingsPage.xaml
@@ -9,10 +9,9 @@
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     mc:Ignorable="d">
 
-    <Grid>
+        <Grid>
         <ScrollViewer>
             <StackPanel Spacing="16" Padding="24">
-                <TextBlock Text="{l10n:Loc Key=Settings_Camouflage_Title}" Style="{ThemeResource TitleTextBlockStyle}" />
                 <TextBlock Text="{l10n:Loc Key=Settings_Camouflage_Description}" Opacity="0.75" TextWrapping="WrapWholeWords" />
 
                 <controls:SettingsCard Header="{l10n:Loc Key=Settings_Camouflage_Enabled_Header}">

--- a/WindBoard/Features/Dock/UI/DockSettingsPage.xaml
+++ b/WindBoard/Features/Dock/UI/DockSettingsPage.xaml
@@ -28,10 +28,9 @@
         </Style>
     </Page.Resources>
 
-    <Grid>
+        <Grid>
         <ScrollViewer>
             <StackPanel Spacing="16" Padding="24">
-                <TextBlock Text="{l10n:Loc Key=Settings_Dock_Title}" Style="{ThemeResource TitleTextBlockStyle}" />
                 <TextBlock
                     Text="{l10n:Loc Key=Settings_Dock_DragHint}"
                     Opacity="0.75"

--- a/WindBoard/Features/Dock/UI/DockSettingsPage.xaml
+++ b/WindBoard/Features/Dock/UI/DockSettingsPage.xaml
@@ -30,13 +30,13 @@
 
         <Grid>
         <ScrollViewer>
-            <StackPanel Spacing="4" Padding="24">
+            <StackPanel Style="{StaticResource SettingsPageRootStackPanelStyle}">
                 <TextBlock
                     Text="{l10n:Loc Key=Settings_Dock_DragHint}"
                     Opacity="0.75"
                     TextWrapping="WrapWholeWords" />
 
-                <StackPanel Spacing="4">
+                <StackPanel Style="{StaticResource SettingsPageSectionStackPanelStyle}">
                     <TextBlock Text="{l10n:Loc Key=Common_Preview}" Style="{ThemeResource SubtitleTextBlockStyle}" />
 
                     <!-- Dock 预览固定为浅色主题，保持与主界面 Dock 视觉一致 -->
@@ -228,7 +228,7 @@
                     </Grid>
                 </StackPanel>
 
-                <StackPanel Spacing="4">
+                <StackPanel Style="{StaticResource SettingsPageSectionStackPanelStyle}">
                     <TextBlock Text="{l10n:Loc Key=Common_Options}" Style="{ThemeResource SubtitleTextBlockStyle}" />
 
                     <controls:SettingsCard Header="{l10n:Loc Key=Settings_Dock_ShowUndoRedo_Header}">
@@ -255,7 +255,7 @@
 
                     <StackPanel
                         x:Name="ShortcutDockEditorPanel"
-                        Spacing="4"
+                        Style="{StaticResource SettingsPageSectionStackPanelStyle}"
                         Visibility="Collapsed">
                         <TextBlock
                             Text="{l10n:Loc Key=Settings_Dock_ShortcutItems_Hint}"

--- a/WindBoard/Features/Dock/UI/DockSettingsPage.xaml
+++ b/WindBoard/Features/Dock/UI/DockSettingsPage.xaml
@@ -30,13 +30,13 @@
 
         <Grid>
         <ScrollViewer>
-            <StackPanel Spacing="16" Padding="24">
+            <StackPanel Spacing="4" Padding="24">
                 <TextBlock
                     Text="{l10n:Loc Key=Settings_Dock_DragHint}"
                     Opacity="0.75"
                     TextWrapping="WrapWholeWords" />
 
-                <StackPanel Spacing="10">
+                <StackPanel Spacing="4">
                     <TextBlock Text="{l10n:Loc Key=Common_Preview}" Style="{ThemeResource SubtitleTextBlockStyle}" />
 
                     <!-- Dock 预览固定为浅色主题，保持与主界面 Dock 视觉一致 -->
@@ -228,7 +228,7 @@
                     </Grid>
                 </StackPanel>
 
-                <StackPanel Spacing="10">
+                <StackPanel Spacing="4">
                     <TextBlock Text="{l10n:Loc Key=Common_Options}" Style="{ThemeResource SubtitleTextBlockStyle}" />
 
                     <controls:SettingsCard Header="{l10n:Loc Key=Settings_Dock_ShowUndoRedo_Header}">
@@ -255,7 +255,7 @@
 
                     <StackPanel
                         x:Name="ShortcutDockEditorPanel"
-                        Spacing="12"
+                        Spacing="4"
                         Visibility="Collapsed">
                         <TextBlock
                             Text="{l10n:Loc Key=Settings_Dock_ShortcutItems_Hint}"

--- a/WindBoard/Features/Shortcuts/UI/ShortcutsSettingsPage.xaml
+++ b/WindBoard/Features/Shortcuts/UI/ShortcutsSettingsPage.xaml
@@ -11,16 +11,16 @@
 
         <Grid>
         <ScrollViewer>
-            <StackPanel Spacing="16" Padding="24">
+            <StackPanel Spacing="4" Padding="24">
                 <TextBlock
                     Text="{l10n:Loc Key=Settings_Shortcuts_Description}"
                     Opacity="0.75"
                     TextWrapping="WrapWholeWords" />
 
-                <StackPanel Spacing="10">
+                <StackPanel Spacing="4">
                     <TextBlock Text="{l10n:Loc Key=Settings_Shortcuts_Keyboard_SectionTitle}" Style="{ThemeResource SubtitleTextBlockStyle}" />
 
-                    <StackPanel Spacing="12">
+                    <StackPanel Spacing="4">
                         <controls:SettingsCard Header="{l10n:Loc Key=Settings_Shortcuts_ConflictReminder_Header}">
                             <controls:SettingsCard.Content>
                                 <ToggleSwitch
@@ -83,14 +83,14 @@
                     </controls:SettingsCard>
                 </StackPanel>
 
-                <StackPanel Spacing="10">
+                <StackPanel Spacing="4">
                     <TextBlock Text="{l10n:Loc Key=Settings_Shortcuts_Mouse_SectionTitle}" Style="{ThemeResource SubtitleTextBlockStyle}" />
                     <TextBlock
                         Text="{l10n:Loc Key=Settings_Shortcuts_Mouse_SectionDescription}"
                         Opacity="0.75"
                         TextWrapping="WrapWholeWords" />
 
-                    <StackPanel Spacing="12">
+                    <StackPanel Spacing="4">
                         <controls:SettingsCard Header="{l10n:Loc Key=Settings_Shortcuts_Mouse_PanViewport_Title}">
                             <controls:SettingsCard.HeaderIcon>
                                 <!-- 平移视口：使用“地图/平移”语义图标 -->

--- a/WindBoard/Features/Shortcuts/UI/ShortcutsSettingsPage.xaml
+++ b/WindBoard/Features/Shortcuts/UI/ShortcutsSettingsPage.xaml
@@ -11,16 +11,16 @@
 
         <Grid>
         <ScrollViewer>
-            <StackPanel Spacing="4" Padding="24">
+            <StackPanel Style="{StaticResource SettingsPageRootStackPanelStyle}">
                 <TextBlock
                     Text="{l10n:Loc Key=Settings_Shortcuts_Description}"
                     Opacity="0.75"
                     TextWrapping="WrapWholeWords" />
 
-                <StackPanel Spacing="4">
+                <StackPanel Style="{StaticResource SettingsPageSectionStackPanelStyle}">
                     <TextBlock Text="{l10n:Loc Key=Settings_Shortcuts_Keyboard_SectionTitle}" Style="{ThemeResource SubtitleTextBlockStyle}" />
 
-                    <StackPanel Spacing="4">
+                    <StackPanel Style="{StaticResource SettingsPageSectionStackPanelStyle}">
                         <controls:SettingsCard Header="{l10n:Loc Key=Settings_Shortcuts_ConflictReminder_Header}">
                             <controls:SettingsCard.Content>
                                 <ToggleSwitch
@@ -83,14 +83,14 @@
                     </controls:SettingsCard>
                 </StackPanel>
 
-                <StackPanel Spacing="4">
+                <StackPanel Style="{StaticResource SettingsPageSectionStackPanelStyle}">
                     <TextBlock Text="{l10n:Loc Key=Settings_Shortcuts_Mouse_SectionTitle}" Style="{ThemeResource SubtitleTextBlockStyle}" />
                     <TextBlock
                         Text="{l10n:Loc Key=Settings_Shortcuts_Mouse_SectionDescription}"
                         Opacity="0.75"
                         TextWrapping="WrapWholeWords" />
 
-                    <StackPanel Spacing="4">
+                    <StackPanel Style="{StaticResource SettingsPageSectionStackPanelStyle}">
                         <controls:SettingsCard Header="{l10n:Loc Key=Settings_Shortcuts_Mouse_PanViewport_Title}">
                             <controls:SettingsCard.HeaderIcon>
                                 <!-- 平移视口：使用“地图/平移”语义图标 -->

--- a/WindBoard/Features/Shortcuts/UI/ShortcutsSettingsPage.xaml
+++ b/WindBoard/Features/Shortcuts/UI/ShortcutsSettingsPage.xaml
@@ -9,10 +9,9 @@
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     mc:Ignorable="d">
 
-    <Grid>
+        <Grid>
         <ScrollViewer>
             <StackPanel Spacing="16" Padding="24">
-                <TextBlock Text="{l10n:Loc Key=Settings_Shortcuts_Title}" Style="{ThemeResource TitleTextBlockStyle}" />
                 <TextBlock
                     Text="{l10n:Loc Key=Settings_Shortcuts_Description}"
                     Opacity="0.75"

--- a/WindBoard/Localization/en-US/SettingsWindow.resx
+++ b/WindBoard/Localization/en-US/SettingsWindow.resx
@@ -35,4 +35,7 @@
   <data name="SettingsWindow_Nav_About" xml:space="preserve">
     <value>About</value>
   </data>
+  <data name="SettingsWindow_Search_Placeholder" xml:space="preserve">
+    <value>Search settings</value>
+  </data>
 </root>

--- a/WindBoard/Localization/zh-CN/SettingsWindow.resx
+++ b/WindBoard/Localization/zh-CN/SettingsWindow.resx
@@ -35,4 +35,7 @@
   <data name="SettingsWindow_Nav_About" xml:space="preserve">
     <value>关于</value>
   </data>
+  <data name="SettingsWindow_Search_Placeholder" xml:space="preserve">
+    <value>搜索设置</value>
+  </data>
 </root>

--- a/WindBoard/Settings/Pages/AboutSettingsPage.xaml
+++ b/WindBoard/Settings/Pages/AboutSettingsPage.xaml
@@ -11,7 +11,7 @@
 
         <Grid>
         <ScrollViewer>
-            <StackPanel Spacing="4" Padding="24">
+            <StackPanel Style="{StaticResource SettingsPageRootStackPanelStyle}">
                 <InfoBar
                     x:Name="DebugUnlockInfoBar"
                     IsOpen="False"

--- a/WindBoard/Settings/Pages/AboutSettingsPage.xaml
+++ b/WindBoard/Settings/Pages/AboutSettingsPage.xaml
@@ -11,7 +11,7 @@
 
         <Grid>
         <ScrollViewer>
-            <StackPanel Spacing="16" Padding="24">
+            <StackPanel Spacing="4" Padding="24">
                 <InfoBar
                     x:Name="DebugUnlockInfoBar"
                     IsOpen="False"
@@ -68,7 +68,6 @@
                     <controls:SettingsCard.Content>
                         <ComboBox
                             x:Name="AutoCheckUpdatesComboBox"
-                            MinWidth="160"
                             SelectedValuePath="Tag"
                             SelectionChanged="OnAutoCheckUpdatesSelectionChanged">
                             <ComboBoxItem Content="{l10n:Loc Key=Settings_About_Interval_Weekly}" Tag="weekly" />
@@ -89,7 +88,6 @@
                     <controls:SettingsCard.Content>
                         <ComboBox
                             x:Name="DownloadSourceComboBox"
-                            MinWidth="160"
                             SelectedValuePath="Tag"
                             SelectionChanged="OnDownloadSourceSelectionChanged">
                             <ComboBoxItem Content="{l10n:Loc Key=Updates_DownloadSource_Auto}" Tag="auto" />

--- a/WindBoard/Settings/Pages/AboutSettingsPage.xaml
+++ b/WindBoard/Settings/Pages/AboutSettingsPage.xaml
@@ -9,11 +9,9 @@
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     mc:Ignorable="d">
 
-    <Grid>
+        <Grid>
         <ScrollViewer>
             <StackPanel Spacing="16" Padding="24">
-                <TextBlock Text="{l10n:Loc Key=Settings_About_Title}" Style="{ThemeResource TitleTextBlockStyle}" />
-
                 <InfoBar
                     x:Name="DebugUnlockInfoBar"
                     IsOpen="False"

--- a/WindBoard/Settings/Pages/AppearanceSettingsPage.xaml
+++ b/WindBoard/Settings/Pages/AppearanceSettingsPage.xaml
@@ -15,11 +15,11 @@
 
         <Grid>
         <ScrollViewer>
-            <StackPanel Spacing="4" Padding="24">
+            <StackPanel Style="{StaticResource SettingsPageRootStackPanelStyle}">
                 <!--
                     顶层入口建议以“卡片网格”呈现：窗口较宽时左右两列，较窄时自动变为单列，避免右侧留白。
                 -->
-                <Grid x:Name="CardsGrid" ColumnSpacing="4" RowSpacing="4">
+                <Grid x:Name="CardsGrid" Style="{StaticResource SettingsPageCardGridStyle}">
                     <Grid.RowDefinitions>
                         <RowDefinition Height="Auto" />
                         <RowDefinition Height="Auto" />

--- a/WindBoard/Settings/Pages/AppearanceSettingsPage.xaml
+++ b/WindBoard/Settings/Pages/AppearanceSettingsPage.xaml
@@ -15,11 +15,11 @@
 
         <Grid>
         <ScrollViewer>
-            <StackPanel Spacing="16" Padding="24">
+            <StackPanel Spacing="4" Padding="24">
                 <!--
                     顶层入口建议以“卡片网格”呈现：窗口较宽时左右两列，较窄时自动变为单列，避免右侧留白。
                 -->
-                <Grid x:Name="CardsGrid" ColumnSpacing="12" RowSpacing="12">
+                <Grid x:Name="CardsGrid" ColumnSpacing="4" RowSpacing="4">
                     <Grid.RowDefinitions>
                         <RowDefinition Height="Auto" />
                         <RowDefinition Height="Auto" />

--- a/WindBoard/Settings/Pages/AppearanceSettingsPage.xaml
+++ b/WindBoard/Settings/Pages/AppearanceSettingsPage.xaml
@@ -13,11 +13,9 @@
         <SolidColorBrush x:Name="CanvasBackgroundPreviewBrush" Color="#2E2F33" />
     </Page.Resources>
 
-    <Grid>
+        <Grid>
         <ScrollViewer>
             <StackPanel Spacing="16" Padding="24">
-                <TextBlock Text="{l10n:Loc Key=Settings_Appearance_Title}" Style="{ThemeResource TitleTextBlockStyle}" />
-
                 <!--
                     顶层入口建议以“卡片网格”呈现：窗口较宽时左右两列，较窄时自动变为单列，避免右侧留白。
                 -->

--- a/WindBoard/Settings/Pages/BackgroundSettingsPage.xaml
+++ b/WindBoard/Settings/Pages/BackgroundSettingsPage.xaml
@@ -14,8 +14,8 @@
 
         <Grid>
         <ScrollViewer>
-            <StackPanel Spacing="16" Padding="24">
-                <StackPanel Spacing="10">
+            <StackPanel Spacing="4" Padding="24">
+                <StackPanel Spacing="4">
                     <TextBlock Text="{l10n:Loc Key=Settings_Background_Canvas_SectionTitle}" Style="{ThemeResource SubtitleTextBlockStyle}" />
 
                     <!-- 入口卡片：点击打开二级弹窗（颜色选择器 + HEX 输入） -->

--- a/WindBoard/Settings/Pages/BackgroundSettingsPage.xaml
+++ b/WindBoard/Settings/Pages/BackgroundSettingsPage.xaml
@@ -14,8 +14,8 @@
 
         <Grid>
         <ScrollViewer>
-            <StackPanel Spacing="4" Padding="24">
-                <StackPanel Spacing="4">
+            <StackPanel Style="{StaticResource SettingsPageRootStackPanelStyle}">
+                <StackPanel Style="{StaticResource SettingsPageSectionStackPanelStyle}">
                     <TextBlock Text="{l10n:Loc Key=Settings_Background_Canvas_SectionTitle}" Style="{ThemeResource SubtitleTextBlockStyle}" />
 
                     <!-- 入口卡片：点击打开二级弹窗（颜色选择器 + HEX 输入） -->

--- a/WindBoard/Settings/Pages/BackgroundSettingsPage.xaml
+++ b/WindBoard/Settings/Pages/BackgroundSettingsPage.xaml
@@ -12,11 +12,9 @@
         <SolidColorBrush x:Name="CanvasBackgroundPreviewBrush" Color="#2E2F33" />
     </Page.Resources>
 
-    <Grid>
+        <Grid>
         <ScrollViewer>
             <StackPanel Spacing="16" Padding="24">
-                <TextBlock Text="{l10n:Loc Key=Settings_Background_Title}" Style="{ThemeResource TitleTextBlockStyle}" />
-
                 <StackPanel Spacing="10">
                     <TextBlock Text="{l10n:Loc Key=Settings_Background_Canvas_SectionTitle}" Style="{ThemeResource SubtitleTextBlockStyle}" />
 

--- a/WindBoard/Settings/Pages/DebugSettingsPage.xaml
+++ b/WindBoard/Settings/Pages/DebugSettingsPage.xaml
@@ -11,7 +11,7 @@
 
         <Grid>
         <ScrollViewer>
-            <StackPanel Spacing="4" Padding="24">
+            <StackPanel Style="{StaticResource SettingsPageRootStackPanelStyle}">
                 <InfoBar
                     x:Name="ActionFeedbackBar"
                     IsOpen="False"
@@ -19,7 +19,7 @@
                     IsIconVisible="True"
                     Severity="Informational" />
 
-                <StackPanel Spacing="4">
+                <StackPanel Style="{StaticResource SettingsPageSectionStackPanelStyle}">
                     <TextBlock Text="{l10n:Loc Key=Settings_Debug_Logs_SectionTitle}" Style="{ThemeResource SubtitleTextBlockStyle}" />
 
                     <controls:SettingsCard
@@ -65,7 +65,7 @@
                     </controls:SettingsCard>
                 </StackPanel>
 
-                <StackPanel Spacing="4">
+                <StackPanel Style="{StaticResource SettingsPageSectionStackPanelStyle}">
                     <TextBlock Text="{l10n:Loc Key=Settings_Debug_SettingsFile_SectionTitle}" Style="{ThemeResource SubtitleTextBlockStyle}" />
 
                     <controls:SettingsCard
@@ -108,7 +108,7 @@
                     </controls:SettingsCard>
                 </StackPanel>
 
-                <StackPanel Spacing="4">
+                <StackPanel Style="{StaticResource SettingsPageSectionStackPanelStyle}">
                     <TextBlock Text="{l10n:Loc Key=Settings_Debug_Tests_SectionTitle}" Style="{ThemeResource SubtitleTextBlockStyle}" />
 
                     <controls:SettingsCard
@@ -168,7 +168,7 @@
                     </controls:SettingsCard>
                 </StackPanel>
 
-                <StackPanel x:Name="SessionSection" Spacing="4">
+                <StackPanel x:Name="SessionSection" Style="{StaticResource SettingsPageSectionStackPanelStyle}">
                     <TextBlock Text="{l10n:Loc Key=Settings_Debug_Session_SectionTitle}" Style="{ThemeResource SubtitleTextBlockStyle}" />
 
                     <controls:SettingsCard

--- a/WindBoard/Settings/Pages/DebugSettingsPage.xaml
+++ b/WindBoard/Settings/Pages/DebugSettingsPage.xaml
@@ -9,11 +9,9 @@
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     mc:Ignorable="d">
 
-    <Grid>
+        <Grid>
         <ScrollViewer>
             <StackPanel Spacing="16" Padding="24">
-                <TextBlock Text="{l10n:Loc Key=Settings_Debug_Title}" Style="{ThemeResource TitleTextBlockStyle}" />
-
                 <InfoBar
                     x:Name="ActionFeedbackBar"
                     IsOpen="False"

--- a/WindBoard/Settings/Pages/DebugSettingsPage.xaml
+++ b/WindBoard/Settings/Pages/DebugSettingsPage.xaml
@@ -11,7 +11,7 @@
 
         <Grid>
         <ScrollViewer>
-            <StackPanel Spacing="16" Padding="24">
+            <StackPanel Spacing="4" Padding="24">
                 <InfoBar
                     x:Name="ActionFeedbackBar"
                     IsOpen="False"
@@ -19,7 +19,7 @@
                     IsIconVisible="True"
                     Severity="Informational" />
 
-                <StackPanel Spacing="10">
+                <StackPanel Spacing="4">
                     <TextBlock Text="{l10n:Loc Key=Settings_Debug_Logs_SectionTitle}" Style="{ThemeResource SubtitleTextBlockStyle}" />
 
                     <controls:SettingsCard
@@ -65,7 +65,7 @@
                     </controls:SettingsCard>
                 </StackPanel>
 
-                <StackPanel Spacing="10">
+                <StackPanel Spacing="4">
                     <TextBlock Text="{l10n:Loc Key=Settings_Debug_SettingsFile_SectionTitle}" Style="{ThemeResource SubtitleTextBlockStyle}" />
 
                     <controls:SettingsCard
@@ -108,7 +108,7 @@
                     </controls:SettingsCard>
                 </StackPanel>
 
-                <StackPanel Spacing="10">
+                <StackPanel Spacing="4">
                     <TextBlock Text="{l10n:Loc Key=Settings_Debug_Tests_SectionTitle}" Style="{ThemeResource SubtitleTextBlockStyle}" />
 
                     <controls:SettingsCard
@@ -168,7 +168,7 @@
                     </controls:SettingsCard>
                 </StackPanel>
 
-                <StackPanel x:Name="SessionSection" Spacing="10">
+                <StackPanel x:Name="SessionSection" Spacing="4">
                     <TextBlock Text="{l10n:Loc Key=Settings_Debug_Session_SectionTitle}" Style="{ThemeResource SubtitleTextBlockStyle}" />
 
                     <controls:SettingsCard

--- a/WindBoard/Settings/Pages/GeneralSettingsPage.xaml
+++ b/WindBoard/Settings/Pages/GeneralSettingsPage.xaml
@@ -11,7 +11,7 @@
 
         <Grid>
         <ScrollViewer>
-            <StackPanel Spacing="16" Padding="24">
+            <StackPanel Spacing="4" Padding="24">
                 <InfoBar
                     x:Name="LanguageRestartInfoBar"
                     IsOpen="False"
@@ -33,7 +33,6 @@
                     <controls:SettingsCard.Content>
                         <ComboBox
                             x:Name="LanguageComboBox"
-                            MinWidth="160"
                             SelectedValuePath="Tag"
                             SelectionChanged="OnLanguageSelectionChanged" />
                     </controls:SettingsCard.Content>
@@ -52,7 +51,6 @@
                     <controls:SettingsCard.Content>
                         <ComboBox
                             x:Name="StartupWindowModeComboBox"
-                            MinWidth="160"
                             SelectedValuePath="Tag"
                             SelectionChanged="OnStartupWindowModeSelectionChanged" />
                     </controls:SettingsCard.Content>

--- a/WindBoard/Settings/Pages/GeneralSettingsPage.xaml
+++ b/WindBoard/Settings/Pages/GeneralSettingsPage.xaml
@@ -9,11 +9,9 @@
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     mc:Ignorable="d">
 
-    <Grid>
+        <Grid>
         <ScrollViewer>
             <StackPanel Spacing="16" Padding="24">
-                <TextBlock Text="{l10n:Loc Key=Settings_General_Title}" Style="{ThemeResource TitleTextBlockStyle}" />
-
                 <InfoBar
                     x:Name="LanguageRestartInfoBar"
                     IsOpen="False"

--- a/WindBoard/Settings/Pages/GeneralSettingsPage.xaml
+++ b/WindBoard/Settings/Pages/GeneralSettingsPage.xaml
@@ -11,7 +11,7 @@
 
         <Grid>
         <ScrollViewer>
-            <StackPanel Spacing="4" Padding="24">
+            <StackPanel Style="{StaticResource SettingsPageRootStackPanelStyle}">
                 <InfoBar
                     x:Name="LanguageRestartInfoBar"
                     IsOpen="False"

--- a/WindBoard/Settings/Pages/PenSettingsPage.xaml
+++ b/WindBoard/Settings/Pages/PenSettingsPage.xaml
@@ -19,11 +19,9 @@
         </Style>
     </Page.Resources>
 
-    <Grid>
+        <Grid>
         <ScrollViewer>
             <StackPanel Spacing="16" Padding="24">
-                <TextBlock Text="{l10n:Loc Key=Settings_Pen_Title}" Style="{ThemeResource TitleTextBlockStyle}" />
-
                 <StackPanel Spacing="10">
                     <TextBlock Text="{l10n:Loc Key=Common_Preview}" Style="{ThemeResource SubtitleTextBlockStyle}" />
 

--- a/WindBoard/Settings/Pages/PenSettingsPage.xaml
+++ b/WindBoard/Settings/Pages/PenSettingsPage.xaml
@@ -21,8 +21,8 @@
 
         <Grid>
         <ScrollViewer>
-            <StackPanel Spacing="16" Padding="24">
-                <StackPanel Spacing="10">
+            <StackPanel Spacing="4" Padding="24">
+                <StackPanel Spacing="4">
                     <TextBlock Text="{l10n:Loc Key=Common_Preview}" Style="{ThemeResource SubtitleTextBlockStyle}" />
 
                     <!-- 预览区域固定为浅色主题，保持与主界面“画笔设置 Flyout”一致 -->
@@ -136,7 +136,7 @@
                     </Border>
                 </StackPanel>
 
-                <StackPanel Spacing="10">
+                <StackPanel Spacing="4">
                     <TextBlock Text="{l10n:Loc Key=Common_Color}" Style="{ThemeResource SubtitleTextBlockStyle}" />
 
                     <controls:SettingsCard
@@ -182,7 +182,7 @@
                     </StackPanel>
                 </StackPanel>
 
-                <StackPanel Spacing="10">
+                <StackPanel Spacing="4">
                     <TextBlock Text="{l10n:Loc Key=Common_Thickness}" Style="{ThemeResource SubtitleTextBlockStyle}" />
 
                     <controls:SettingsCard Header="{l10n:Loc Key=Settings_Pen_UseThicknessSlider_Header}">
@@ -196,10 +196,10 @@
                         </controls:SettingsCard.Content>
                     </controls:SettingsCard>
 
-                    <StackPanel x:Name="ThicknessPresetsEditorPanel" Spacing="12">
+                    <StackPanel x:Name="ThicknessPresetsEditorPanel" Spacing="4">
                         <TextBlock Text="{l10n:Loc Key=Settings_Pen_ThicknessPresets_Hint}" Opacity="0.75" TextWrapping="WrapWholeWords" />
 
-                        <Grid ColumnSpacing="12">
+                        <Grid ColumnSpacing="4">
                             <Grid.ColumnDefinitions>
                                 <ColumnDefinition Width="*" />
                                 <ColumnDefinition Width="*" />
@@ -207,9 +207,7 @@
                             </Grid.ColumnDefinitions>
 
                             <controls:SettingsCard
-                                Header="{l10n:Loc Key=Settings_Pen_ThicknessPreset1_Header}"
-                                ContentAlignment="Vertical"
-                                HorizontalContentAlignment="Stretch">
+                                Header="{l10n:Loc Key=Settings_Pen_ThicknessPreset1_Header}">
                                 <controls:SettingsCard.Content>
                                     <NumberBox
                                         x:Name="ThicknessPreset1NumberBox"
@@ -225,9 +223,7 @@
 
                             <controls:SettingsCard
                                 Grid.Column="1"
-                                Header="{l10n:Loc Key=Settings_Pen_ThicknessPreset2_Header}"
-                                ContentAlignment="Vertical"
-                                HorizontalContentAlignment="Stretch">
+                                Header="{l10n:Loc Key=Settings_Pen_ThicknessPreset2_Header}">
                                 <controls:SettingsCard.Content>
                                     <NumberBox
                                         x:Name="ThicknessPreset2NumberBox"
@@ -243,9 +239,7 @@
 
                             <controls:SettingsCard
                                 Grid.Column="2"
-                                Header="{l10n:Loc Key=Settings_Pen_ThicknessPreset3_Header}"
-                                ContentAlignment="Vertical"
-                                HorizontalContentAlignment="Stretch">
+                                Header="{l10n:Loc Key=Settings_Pen_ThicknessPreset3_Header}">
                                 <controls:SettingsCard.Content>
                                     <NumberBox
                                         x:Name="ThicknessPreset3NumberBox"

--- a/WindBoard/Settings/Pages/PenSettingsPage.xaml
+++ b/WindBoard/Settings/Pages/PenSettingsPage.xaml
@@ -21,8 +21,8 @@
 
         <Grid>
         <ScrollViewer>
-            <StackPanel Spacing="4" Padding="24">
-                <StackPanel Spacing="4">
+            <StackPanel Style="{StaticResource SettingsPageRootStackPanelStyle}">
+                <StackPanel Style="{StaticResource SettingsPageSectionStackPanelStyle}">
                     <TextBlock Text="{l10n:Loc Key=Common_Preview}" Style="{ThemeResource SubtitleTextBlockStyle}" />
 
                     <!-- 预览区域固定为浅色主题，保持与主界面“画笔设置 Flyout”一致 -->
@@ -136,7 +136,7 @@
                     </Border>
                 </StackPanel>
 
-                <StackPanel Spacing="4">
+                <StackPanel Style="{StaticResource SettingsPageSectionStackPanelStyle}">
                     <TextBlock Text="{l10n:Loc Key=Common_Color}" Style="{ThemeResource SubtitleTextBlockStyle}" />
 
                     <controls:SettingsCard
@@ -182,7 +182,7 @@
                     </StackPanel>
                 </StackPanel>
 
-                <StackPanel Spacing="4">
+                <StackPanel Style="{StaticResource SettingsPageSectionStackPanelStyle}">
                     <TextBlock Text="{l10n:Loc Key=Common_Thickness}" Style="{ThemeResource SubtitleTextBlockStyle}" />
 
                     <controls:SettingsCard Header="{l10n:Loc Key=Settings_Pen_UseThicknessSlider_Header}">
@@ -196,10 +196,10 @@
                         </controls:SettingsCard.Content>
                     </controls:SettingsCard>
 
-                    <StackPanel x:Name="ThicknessPresetsEditorPanel" Spacing="4">
+                    <StackPanel x:Name="ThicknessPresetsEditorPanel" Style="{StaticResource SettingsPageSectionStackPanelStyle}">
                         <TextBlock Text="{l10n:Loc Key=Settings_Pen_ThicknessPresets_Hint}" Opacity="0.75" TextWrapping="WrapWholeWords" />
 
-                        <Grid ColumnSpacing="4">
+                        <Grid Style="{StaticResource SettingsPageCardGridStyle}">
                             <Grid.ColumnDefinitions>
                                 <ColumnDefinition Width="*" />
                                 <ColumnDefinition Width="*" />

--- a/WindBoard/Settings/Pages/SettingsManagementPage.xaml
+++ b/WindBoard/Settings/Pages/SettingsManagementPage.xaml
@@ -11,7 +11,7 @@
 
         <Grid>
         <ScrollViewer>
-            <StackPanel Spacing="16" Padding="24">
+            <StackPanel Spacing="4" Padding="24">
                 <InfoBar
                     x:Name="SettingsManagementFeedbackBar"
                     IsOpen="False"

--- a/WindBoard/Settings/Pages/SettingsManagementPage.xaml
+++ b/WindBoard/Settings/Pages/SettingsManagementPage.xaml
@@ -11,7 +11,7 @@
 
         <Grid>
         <ScrollViewer>
-            <StackPanel Spacing="4" Padding="24">
+            <StackPanel Style="{StaticResource SettingsPageRootStackPanelStyle}">
                 <InfoBar
                     x:Name="SettingsManagementFeedbackBar"
                     IsOpen="False"

--- a/WindBoard/Settings/Pages/SettingsManagementPage.xaml
+++ b/WindBoard/Settings/Pages/SettingsManagementPage.xaml
@@ -9,13 +9,9 @@
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     mc:Ignorable="d">
 
-    <Grid>
+        <Grid>
         <ScrollViewer>
             <StackPanel Spacing="16" Padding="24">
-                <TextBlock
-                    Text="{l10n:Loc Key=Settings_About_SettingsManagement_SectionTitle}"
-                    Style="{ThemeResource TitleTextBlockStyle}" />
-
                 <InfoBar
                     x:Name="SettingsManagementFeedbackBar"
                     IsOpen="False"

--- a/WindBoard/Settings/Pages/WritingSettingsPage.xaml
+++ b/WindBoard/Settings/Pages/WritingSettingsPage.xaml
@@ -11,7 +11,7 @@
 
         <Grid>
         <ScrollViewer>
-            <StackPanel Spacing="16" Padding="24">
+            <StackPanel Spacing="4" Padding="24">
                 <controls:SettingsCard
                     x:Name="PenSettingsCard"
                     IsClickEnabled="True"

--- a/WindBoard/Settings/Pages/WritingSettingsPage.xaml
+++ b/WindBoard/Settings/Pages/WritingSettingsPage.xaml
@@ -11,7 +11,7 @@
 
         <Grid>
         <ScrollViewer>
-            <StackPanel Spacing="4" Padding="24">
+            <StackPanel Style="{StaticResource SettingsPageRootStackPanelStyle}">
                 <controls:SettingsCard
                     x:Name="PenSettingsCard"
                     IsClickEnabled="True"

--- a/WindBoard/Settings/Pages/WritingSettingsPage.xaml
+++ b/WindBoard/Settings/Pages/WritingSettingsPage.xaml
@@ -9,11 +9,9 @@
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     mc:Ignorable="d">
 
-    <Grid>
+        <Grid>
         <ScrollViewer>
             <StackPanel Spacing="16" Padding="24">
-                <TextBlock Text="{l10n:Loc Key=Settings_Writing_Title}" Style="{ThemeResource TitleTextBlockStyle}" />
-
                 <controls:SettingsCard
                     x:Name="PenSettingsCard"
                     IsClickEnabled="True"

--- a/WindBoard/Settings/SettingsPageResources.xaml
+++ b/WindBoard/Settings/SettingsPageResources.xaml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ResourceDictionary
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+
+    <x:Double x:Key="SettingsCardGroupSpacing">4</x:Double>
+    <Thickness x:Key="SettingsPagePadding">24</Thickness>
+
+    <Style x:Key="SettingsPageRootStackPanelStyle" TargetType="StackPanel">
+        <Setter Property="Spacing" Value="{StaticResource SettingsCardGroupSpacing}" />
+        <Setter Property="Padding" Value="{StaticResource SettingsPagePadding}" />
+    </Style>
+
+    <Style x:Key="SettingsPageSectionStackPanelStyle" TargetType="StackPanel">
+        <Setter Property="Spacing" Value="{StaticResource SettingsCardGroupSpacing}" />
+    </Style>
+
+    <Style x:Key="SettingsPageCardGridStyle" TargetType="Grid">
+        <Setter Property="RowSpacing" Value="{StaticResource SettingsCardGroupSpacing}" />
+        <Setter Property="ColumnSpacing" Value="{StaticResource SettingsCardGroupSpacing}" />
+    </Style>
+</ResourceDictionary>

--- a/WindBoard/Settings/SettingsWindow.xaml
+++ b/WindBoard/Settings/SettingsWindow.xaml
@@ -13,54 +13,87 @@
         <MicaBackdrop />
     </Window.SystemBackdrop>
 
-    <NavigationView
-        x:Name="NavView"
-        IsBackButtonVisible="Collapsed"
-        BackRequested="OnBackRequested"
-        AlwaysShowHeader="False"
-        IsSettingsVisible="False"
-        PaneDisplayMode="Left"
-        SelectionChanged="OnNavigationSelectionChanged">
-        <NavigationView.MenuItems>
-            <NavigationViewItem Content="{l10n:Loc Key=SettingsWindow_Nav_General}" Tag="general">
-                <NavigationViewItem.Icon>
-                    <SymbolIcon Symbol="Setting" />
-                </NavigationViewItem.Icon>
-            </NavigationViewItem>
-            <NavigationViewItem Content="{l10n:Loc Key=SettingsWindow_Nav_Appearance}" Tag="appearance">
-                <NavigationViewItem.Icon>
-                    <!-- 外观：用“调色板/颜色”语义图标，避免与其它项重复 -->
-                    <FontIcon FontFamily="{ThemeResource SymbolThemeFontFamily}" Glyph="&#xE790;" />
-                </NavigationViewItem.Icon>
-            </NavigationViewItem>
-            <NavigationViewItem Content="{l10n:Loc Key=SettingsWindow_Nav_Writing}" Tag="writing">
-                <NavigationViewItem.Icon>
-                    <SymbolIcon Symbol="Edit" />
-                </NavigationViewItem.Icon>
-            </NavigationViewItem>
-            <NavigationViewItem Content="{l10n:Loc Key=SettingsWindow_Nav_Shortcuts}" Tag="shortcuts">
-                <NavigationViewItem.Icon>
-                    <!-- 快捷键：键盘语义图标 -->
-                    <FontIcon FontFamily="{ThemeResource SymbolThemeFontFamily}" Glyph="&#xE765;" />
-                </NavigationViewItem.Icon>
-            </NavigationViewItem>
-        </NavigationView.MenuItems>
+    <Grid>
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="*" />
+        </Grid.RowDefinitions>
 
-        <NavigationView.FooterMenuItems>
-            <NavigationViewItem x:Name="DebugNavItem" Content="{l10n:Loc Key=SettingsWindow_Nav_Debug}" Tag="debug" Visibility="Collapsed">
-                <NavigationViewItem.Icon>
-                    <!-- 调试：工具语义图标 -->
-                    <FontIcon FontFamily="{ThemeResource SymbolThemeFontFamily}" Glyph="&#xE9D9;" />
-                </NavigationViewItem.Icon>
-            </NavigationViewItem>
-            <NavigationViewItem Content="{l10n:Loc Key=SettingsWindow_Nav_About}" Tag="about">
-                <NavigationViewItem.Icon>
-                    <!-- 关于：信息语义图标 -->
-                    <FontIcon FontFamily="{ThemeResource SymbolThemeFontFamily}" Glyph="&#xE946;" />
-                </NavigationViewItem.Icon>
-            </NavigationViewItem>
-        </NavigationView.FooterMenuItems>
+        <TitleBar
+            x:Name="AppTitleBar"
+            Grid.Row="0"
+            IsBackButtonVisible="False"
+            IsBackButtonEnabled="False"
+            IsPaneToggleButtonVisible="True"
+            BackRequested="OnTitleBarBackRequested"
+            PaneToggleRequested="OnTitleBarPaneToggleRequested">
+            <TitleBar.Content>
+                <AutoSuggestBox
+                    x:Name="SettingsSearchBox"
+                    Width="320"
+                    MinWidth="220"
+                    MaxWidth="420"
+                    VerticalAlignment="Center"
+                    PlaceholderText="{l10n:Loc Key=SettingsWindow_Search_Placeholder}"
+                    QueryIcon="Find"
+                    SuggestionChosen="OnSettingsSearchSuggestionChosen"
+                    QuerySubmitted="OnSettingsSearchQuerySubmitted"
+                    TextChanged="OnSettingsSearchTextChanged" />
+            </TitleBar.Content>
+        </TitleBar>
 
-        <Frame x:Name="ContentFrame" Navigated="OnContentFrameNavigated" />
-    </NavigationView>
+        <NavigationView
+            x:Name="NavView"
+            Grid.Row="1"
+            AlwaysShowHeader="False"
+            IsBackButtonVisible="Collapsed"
+            IsPaneOpen="True"
+            IsPaneToggleButtonVisible="False"
+            IsSettingsVisible="False"
+            IsTitleBarAutoPaddingEnabled="False"
+            PaneDisplayMode="Left"
+            SelectionChanged="OnNavigationSelectionChanged">
+            <NavigationView.MenuItems>
+                <NavigationViewItem Content="{l10n:Loc Key=SettingsWindow_Nav_General}" Tag="general">
+                    <NavigationViewItem.Icon>
+                        <SymbolIcon Symbol="Setting" />
+                    </NavigationViewItem.Icon>
+                </NavigationViewItem>
+                <NavigationViewItem Content="{l10n:Loc Key=SettingsWindow_Nav_Appearance}" Tag="appearance">
+                    <NavigationViewItem.Icon>
+                        <!-- 外观：用“调色板/颜色”语义图标，避免与其它项重复 -->
+                        <FontIcon FontFamily="{ThemeResource SymbolThemeFontFamily}" Glyph="&#xE790;" />
+                    </NavigationViewItem.Icon>
+                </NavigationViewItem>
+                <NavigationViewItem Content="{l10n:Loc Key=SettingsWindow_Nav_Writing}" Tag="writing">
+                    <NavigationViewItem.Icon>
+                        <SymbolIcon Symbol="Edit" />
+                    </NavigationViewItem.Icon>
+                </NavigationViewItem>
+                <NavigationViewItem Content="{l10n:Loc Key=SettingsWindow_Nav_Shortcuts}" Tag="shortcuts">
+                    <NavigationViewItem.Icon>
+                        <!-- 快捷键：键盘语义图标 -->
+                        <FontIcon FontFamily="{ThemeResource SymbolThemeFontFamily}" Glyph="&#xE765;" />
+                    </NavigationViewItem.Icon>
+                </NavigationViewItem>
+            </NavigationView.MenuItems>
+
+            <NavigationView.FooterMenuItems>
+                <NavigationViewItem x:Name="DebugNavItem" Content="{l10n:Loc Key=SettingsWindow_Nav_Debug}" Tag="debug" Visibility="Collapsed">
+                    <NavigationViewItem.Icon>
+                        <!-- 调试：工具语义图标 -->
+                        <FontIcon FontFamily="{ThemeResource SymbolThemeFontFamily}" Glyph="&#xE9D9;" />
+                    </NavigationViewItem.Icon>
+                </NavigationViewItem>
+                <NavigationViewItem Content="{l10n:Loc Key=SettingsWindow_Nav_About}" Tag="about">
+                    <NavigationViewItem.Icon>
+                        <!-- 关于：信息语义图标 -->
+                        <FontIcon FontFamily="{ThemeResource SymbolThemeFontFamily}" Glyph="&#xE946;" />
+                    </NavigationViewItem.Icon>
+                </NavigationViewItem>
+            </NavigationView.FooterMenuItems>
+
+            <Frame x:Name="ContentFrame" Navigated="OnContentFrameNavigated" />
+        </NavigationView>
+    </Grid>
 </Window>

--- a/WindBoard/Settings/SettingsWindow.xaml.cs
+++ b/WindBoard/Settings/SettingsWindow.xaml.cs
@@ -1,12 +1,25 @@
 using System;
+using System.Collections.Generic;
+using Microsoft.UI;
+using Microsoft.UI.Windowing;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
+using WindBoard.Features.Camouflage.UI;
+using WindBoard.Features.Dock.UI;
+using WindBoard.Features.Shortcuts.UI;
+using WindBoard.Localization;
 using WindBoard.Settings.Pages;
 
 namespace WindBoard.Settings
 {
     public sealed partial class SettingsWindow : Window
     {
+        private readonly List<SettingsSearchTarget> _searchTargets = new();
+        private readonly List<SettingsSearchTarget> _filteredSearchTargets = new();
+        private AppWindowTitleBar? _appWindowTitleBar;
+        private string? _pendingBringIntoViewElementName;
+        private Type? _pendingBringIntoViewPageType;
+
         internal static SettingsWindow? Active { get; private set; }
 
         internal IntPtr Hwnd
@@ -27,6 +40,10 @@ namespace WindBoard.Settings
         public SettingsWindow()
         {
             InitializeComponent();
+
+            ConfigureTitleBar();
+            RebuildSearchTargets();
+            UpdateCurrentPageTitle();
 
             Active = this;
             Closed += (_, _) =>
@@ -55,16 +72,32 @@ namespace WindBoard.Settings
                     NavigateFromTag(item.Tag as string);
                 }
             };
+
         }
 
-        private void OnBackRequested(NavigationView sender, NavigationViewBackRequestedEventArgs args)
+        private void ConfigureTitleBar()
         {
-            if (!ContentFrame.CanGoBack)
-            {
-                return;
-            }
+            ExtendsContentIntoTitleBar = true;
+            SetTitleBar(AppTitleBar);
 
-            ContentFrame.GoBack();
+            _appWindowTitleBar = AppWindow.TitleBar;
+            _appWindowTitleBar.PreferredHeightOption = TitleBarHeightOption.Tall;
+            _appWindowTitleBar.ButtonBackgroundColor = Colors.Transparent;
+            _appWindowTitleBar.ButtonInactiveBackgroundColor = Colors.Transparent;
+        }
+
+        private void OnTitleBarPaneToggleRequested(TitleBar sender, object args)
+        {
+            bool shouldExpand = NavView.PaneDisplayMode != NavigationViewPaneDisplayMode.Left || !NavView.IsPaneOpen;
+            NavView.PaneDisplayMode = shouldExpand
+                ? NavigationViewPaneDisplayMode.Left
+                : NavigationViewPaneDisplayMode.LeftCompact;
+            NavView.IsPaneOpen = shouldExpand;
+        }
+
+        private void OnTitleBarBackRequested(TitleBar sender, object args)
+        {
+            TryGoBack();
         }
 
         private void OnNavigationSelectionChanged(NavigationView sender, NavigationViewSelectionChangedEventArgs args)
@@ -80,6 +113,8 @@ namespace WindBoard.Settings
         private void OnContentFrameNavigated(object sender, Microsoft.UI.Xaml.Navigation.NavigationEventArgs e)
         {
             UpdateBackButtonState();
+            UpdateCurrentPageTitle();
+            TryBringPendingElementIntoView();
         }
 
         private void NavigateFromTag(string? tag)
@@ -110,6 +145,20 @@ namespace WindBoard.Settings
             UpdateBackButtonState();
         }
 
+        private static Type GetPageTypeFromTag(string? tag)
+        {
+            return tag switch
+            {
+                "general" => typeof(GeneralSettingsPage),
+                "appearance" => typeof(AppearanceSettingsPage),
+                "writing" => typeof(WritingSettingsPage),
+                "shortcuts" => typeof(ShortcutsSettingsPage),
+                "debug" => typeof(DebugSettingsPage),
+                "about" => typeof(AboutSettingsPage),
+                _ => typeof(GeneralSettingsPage),
+            };
+        }
+
         private void OnDebugToolsGateChanged(object? sender, EventArgs e)
         {
             // Gate 事件可能来自非 UI 线程，这里统一切回 UI 线程更新。
@@ -128,6 +177,8 @@ namespace WindBoard.Settings
 
             bool visible = DebugToolsGate.IsVisible;
             DebugNavItem.Visibility = visible ? Visibility.Visible : Visibility.Collapsed;
+            RebuildSearchTargets();
+            RefreshSearchSuggestions(SettingsSearchBox.Text);
 
             // 防御：入口被隐藏时，如果用户仍停留在调试页，自动回到“常规”。
             if (!visible && ContentFrame.CurrentSourcePageType == typeof(DebugSettingsPage))
@@ -152,9 +203,386 @@ namespace WindBoard.Settings
         {
             bool canGoBack = ContentFrame.CanGoBack;
             NavView.IsBackEnabled = canGoBack;
-            NavView.IsBackButtonVisible = canGoBack
-                ? NavigationViewBackButtonVisible.Visible
-                : NavigationViewBackButtonVisible.Collapsed;
+            AppTitleBar.IsBackButtonVisible = canGoBack;
+            AppTitleBar.IsBackButtonEnabled = canGoBack;
+        }
+
+        private bool TryGoBack()
+        {
+            if (!ContentFrame.CanGoBack)
+            {
+                return false;
+            }
+
+            ContentFrame.GoBack();
+            return true;
+        }
+
+        private void UpdateCurrentPageTitle()
+        {
+            string pageTitle = GetPageTitle(ContentFrame.CurrentSourcePageType);
+            if (string.IsNullOrWhiteSpace(pageTitle))
+            {
+                pageTitle = L10n.Get("Common_Settings");
+            }
+
+            AppTitleBar.Title = pageTitle;
+            Title = $"{L10n.Get("Common_Settings")} - {pageTitle}";
+        }
+
+        private static string GetPageTitle(Type? pageType)
+        {
+            if (pageType == typeof(GeneralSettingsPage))
+            {
+                return L10n.Get("Settings_General_Title");
+            }
+
+            if (pageType == typeof(AppearanceSettingsPage))
+            {
+                return L10n.Get("Settings_Appearance_Title");
+            }
+
+            if (pageType == typeof(WritingSettingsPage))
+            {
+                return L10n.Get("Settings_Writing_Title");
+            }
+
+            if (pageType == typeof(ShortcutsSettingsPage))
+            {
+                return L10n.Get("Settings_Shortcuts_Title");
+            }
+
+            if (pageType == typeof(DebugSettingsPage))
+            {
+                return L10n.Get("Settings_Debug_Title");
+            }
+
+            if (pageType == typeof(AboutSettingsPage))
+            {
+                return L10n.Get("Settings_About_Title");
+            }
+
+            if (pageType == typeof(CamouflageSettingsPage))
+            {
+                return L10n.Get("Settings_Camouflage_Title");
+            }
+
+            if (pageType == typeof(DockSettingsPage))
+            {
+                return L10n.Get("Settings_Dock_Title");
+            }
+
+            if (pageType == typeof(PenSettingsPage))
+            {
+                return L10n.Get("Settings_Pen_Title");
+            }
+
+            if (pageType == typeof(SettingsManagementPage))
+            {
+                return L10n.Get("Settings_About_SettingsManagement_SectionTitle");
+            }
+
+            return string.Empty;
+        }
+
+        private static string GetRootTitle(string rootTag)
+        {
+            return rootTag switch
+            {
+                "general" => L10n.Get("Settings_General_Title"),
+                "appearance" => L10n.Get("Settings_Appearance_Title"),
+                "writing" => L10n.Get("Settings_Writing_Title"),
+                "shortcuts" => L10n.Get("Settings_Shortcuts_Title"),
+                "debug" => L10n.Get("Settings_Debug_Title"),
+                "about" => L10n.Get("Settings_About_Title"),
+                _ => L10n.Get("Common_Settings"),
+            };
+        }
+
+        private void RebuildSearchTargets()
+        {
+            _searchTargets.Clear();
+
+            AddSearchTarget("general", null, "Settings_General_Title");
+            AddSearchTarget("general", null, "Settings_General_Language_Title", "Settings_General_Language_Description", "LanguageComboBox");
+            AddSearchTarget("general", null, "Settings_General_StartupWindowMode_Title", "Settings_General_StartupWindowMode_Description", "StartupWindowModeComboBox");
+            AddSearchTarget("general", null, "Settings_General_EnterScreenAnnotationWhenMinimized_Title", "Settings_General_EnterScreenAnnotationWhenMinimized_Description", "EnterScreenAnnotationWhenMinimizedToggleSwitch");
+            AddSearchTarget("general", typeof(CamouflageSettingsPage), "Settings_Camouflage_Title", "Settings_Camouflage_Description", "EnabledToggleSwitch");
+
+            AddSearchTarget("appearance", null, "Settings_Appearance_Title");
+            AddSearchTarget("appearance", null, "Settings_Background_CanvasBackgroundColor_Title", "Settings_Background_CanvasBackgroundColor_Description", "CanvasBackgroundCard");
+            AddSearchTarget("appearance", null, "Settings_Appearance_ElementCardTheme_Title", "Settings_Appearance_ElementCardTheme_Description", "ElementCardThemeCard");
+            AddSearchTarget("appearance", typeof(DockSettingsPage), "Settings_Dock_Title", "Settings_Dock_Description", "UndoRedoVisibleToggleSwitch");
+
+            AddSearchTarget("writing", null, "Settings_Writing_Title");
+            AddSearchTarget("writing", typeof(PenSettingsPage), "Settings_Pen_Title", "Settings_Writing_Pen_Description", "PaletteCountNumberBox");
+
+            AddSearchTarget("shortcuts", null, "Settings_Shortcuts_Title", "Settings_Shortcuts_Description");
+            AddSearchTarget("shortcuts", null, "Settings_Shortcuts_ConflictReminder_Header", null, "ConflictReminderToggleSwitch");
+            AddSearchTarget("shortcuts", null, "Settings_Shortcuts_Undo_Title", null, "UndoShortcutCard");
+            AddSearchTarget("shortcuts", null, "Settings_Shortcuts_Redo_Title", null, "RedoShortcutCard");
+
+            AddSearchTarget("about", null, "Settings_About_Title");
+            AddSearchTarget("about", typeof(SettingsManagementPage), "Settings_About_SettingsManagement_SectionTitle", "Settings_About_SettingsManagement_Entry_Description", "ExportSettingsCard");
+            AddSearchTarget("about", null, "Settings_About_AutoCheckUpdates", null, "AutoCheckUpdatesComboBox");
+            AddSearchTarget("about", null, "Updates_DownloadSource_Title", null, "DownloadSourceComboBox");
+            AddSearchTarget("about", null, "Settings_About_CheckUpdates", null, "CheckUpdatesButton");
+
+            if (DebugToolsGate.IsVisible)
+            {
+                AddSearchTarget("debug", null, "Settings_Debug_Title");
+                AddSearchTarget("debug", null, "Settings_Debug_OpenLogDir_Title", "Settings_Debug_OpenLogDir_Description");
+                AddSearchTarget("debug", null, "Settings_Debug_OpenSettingsDir_Title", "Settings_Debug_OpenSettingsDir_Description");
+                AddSearchTarget("debug", null, "Settings_Debug_SendTestToast_Title", "Settings_Debug_SendTestToast_Description");
+            }
+        }
+
+        private void AddSearchTarget(string rootTag, Type? detailPageType, string titleKey, string? descriptionKey = null, string? focusElementName = null)
+        {
+            string rootTitle = GetRootTitle(rootTag);
+            string title = GetSearchResource(titleKey);
+            string displayText = string.Equals(rootTitle, title, StringComparison.Ordinal)
+                ? title
+                : $"{rootTitle} / {title}";
+
+            string searchText = displayText;
+            if (!string.IsNullOrWhiteSpace(descriptionKey))
+            {
+                searchText = $"{searchText} {GetSearchResource(descriptionKey)}";
+            }
+
+            _searchTargets.Add(new SettingsSearchTarget(displayText, searchText, rootTag, detailPageType, focusElementName));
+        }
+
+        private static string GetSearchResource(string key)
+        {
+            return key switch
+            {
+                "Settings_General_Title" => L10n.Get("Settings_General_Title"),
+                "Settings_General_Language_Title" => L10n.Get("Settings_General_Language_Title"),
+                "Settings_General_Language_Description" => L10n.Get("Settings_General_Language_Description"),
+                "Settings_General_StartupWindowMode_Title" => L10n.Get("Settings_General_StartupWindowMode_Title"),
+                "Settings_General_StartupWindowMode_Description" => L10n.Get("Settings_General_StartupWindowMode_Description"),
+                "Settings_General_EnterScreenAnnotationWhenMinimized_Title" => L10n.Get("Settings_General_EnterScreenAnnotationWhenMinimized_Title"),
+                "Settings_General_EnterScreenAnnotationWhenMinimized_Description" => L10n.Get("Settings_General_EnterScreenAnnotationWhenMinimized_Description"),
+                "Settings_Camouflage_Title" => L10n.Get("Settings_Camouflage_Title"),
+                "Settings_Camouflage_Description" => L10n.Get("Settings_Camouflage_Description"),
+                "Settings_Appearance_Title" => L10n.Get("Settings_Appearance_Title"),
+                "Settings_Background_CanvasBackgroundColor_Title" => L10n.Get("Settings_Background_CanvasBackgroundColor_Title"),
+                "Settings_Background_CanvasBackgroundColor_Description" => L10n.Get("Settings_Background_CanvasBackgroundColor_Description"),
+                "Settings_Appearance_ElementCardTheme_Title" => L10n.Get("Settings_Appearance_ElementCardTheme_Title"),
+                "Settings_Appearance_ElementCardTheme_Description" => L10n.Get("Settings_Appearance_ElementCardTheme_Description"),
+                "Settings_Dock_Title" => L10n.Get("Settings_Dock_Title"),
+                "Settings_Dock_Description" => L10n.Get("Settings_Dock_Description"),
+                "Settings_Writing_Title" => L10n.Get("Settings_Writing_Title"),
+                "Settings_Pen_Title" => L10n.Get("Settings_Pen_Title"),
+                "Settings_Writing_Pen_Description" => L10n.Get("Settings_Writing_Pen_Description"),
+                "Settings_Shortcuts_Title" => L10n.Get("Settings_Shortcuts_Title"),
+                "Settings_Shortcuts_Description" => L10n.Get("Settings_Shortcuts_Description"),
+                "Settings_Shortcuts_ConflictReminder_Header" => L10n.Get("Settings_Shortcuts_ConflictReminder_Header"),
+                "Settings_Shortcuts_Undo_Title" => L10n.Get("Settings_Shortcuts_Undo_Title"),
+                "Settings_Shortcuts_Redo_Title" => L10n.Get("Settings_Shortcuts_Redo_Title"),
+                "Settings_About_Title" => L10n.Get("Settings_About_Title"),
+                "Settings_About_SettingsManagement_SectionTitle" => L10n.Get("Settings_About_SettingsManagement_SectionTitle"),
+                "Settings_About_SettingsManagement_Entry_Description" => L10n.Get("Settings_About_SettingsManagement_Entry_Description"),
+                "Settings_About_AutoCheckUpdates" => L10n.Get("Settings_About_AutoCheckUpdates"),
+                "Updates_DownloadSource_Title" => L10n.Get("Updates_DownloadSource_Title"),
+                "Settings_About_CheckUpdates" => L10n.Get("Settings_About_CheckUpdates"),
+                "Settings_Debug_Title" => L10n.Get("Settings_Debug_Title"),
+                "Settings_Debug_OpenLogDir_Title" => L10n.Get("Settings_Debug_OpenLogDir_Title"),
+                "Settings_Debug_OpenLogDir_Description" => L10n.Get("Settings_Debug_OpenLogDir_Description"),
+                "Settings_Debug_OpenSettingsDir_Title" => L10n.Get("Settings_Debug_OpenSettingsDir_Title"),
+                "Settings_Debug_OpenSettingsDir_Description" => L10n.Get("Settings_Debug_OpenSettingsDir_Description"),
+                "Settings_Debug_SendTestToast_Title" => L10n.Get("Settings_Debug_SendTestToast_Title"),
+                "Settings_Debug_SendTestToast_Description" => L10n.Get("Settings_Debug_SendTestToast_Description"),
+                _ => key,
+            };
+        }
+
+        private void OnSettingsSearchTextChanged(AutoSuggestBox sender, AutoSuggestBoxTextChangedEventArgs args)
+        {
+            if (args.Reason != AutoSuggestionBoxTextChangeReason.UserInput)
+            {
+                return;
+            }
+
+            RefreshSearchSuggestions(sender.Text);
+        }
+
+        private void RefreshSearchSuggestions(string? query)
+        {
+            _filteredSearchTargets.Clear();
+            SettingsSearchBox.ItemsSource = null;
+
+            if (string.IsNullOrWhiteSpace(query))
+            {
+                return;
+            }
+
+            foreach (SettingsSearchTarget target in _searchTargets)
+            {
+                if (!target.SearchText.Contains(query, StringComparison.OrdinalIgnoreCase))
+                {
+                    continue;
+                }
+
+                _filteredSearchTargets.Add(target);
+                if (_filteredSearchTargets.Count >= 8)
+                {
+                    break;
+                }
+            }
+
+            if (_filteredSearchTargets.Count == 0)
+            {
+                return;
+            }
+
+            List<string> suggestions = new(_filteredSearchTargets.Count);
+            foreach (SettingsSearchTarget target in _filteredSearchTargets)
+            {
+                suggestions.Add(target.DisplayText);
+            }
+
+            SettingsSearchBox.ItemsSource = suggestions;
+        }
+
+        private void OnSettingsSearchSuggestionChosen(AutoSuggestBox sender, AutoSuggestBoxSuggestionChosenEventArgs args)
+        {
+            if (args.SelectedItem is not string displayText)
+            {
+                return;
+            }
+
+            SettingsSearchTarget? target = FindSearchTarget(displayText);
+            if (target is null)
+            {
+                return;
+            }
+
+            sender.Text = target.DisplayText;
+        }
+
+        private void OnSettingsSearchQuerySubmitted(AutoSuggestBox sender, AutoSuggestBoxQuerySubmittedEventArgs args)
+        {
+            SettingsSearchTarget? target = null;
+
+            if (args.ChosenSuggestion is string displayText)
+            {
+                target = FindSearchTarget(displayText);
+            }
+
+            target ??= _filteredSearchTargets.Count > 0 ? _filteredSearchTargets[0] : null;
+            if (target is null)
+            {
+                return;
+            }
+
+            sender.Text = target.DisplayText;
+            NavigateToSearchTarget(target);
+        }
+
+        private SettingsSearchTarget? FindSearchTarget(string displayText)
+        {
+            foreach (SettingsSearchTarget target in _searchTargets)
+            {
+                if (string.Equals(target.DisplayText, displayText, StringComparison.Ordinal))
+                {
+                    return target;
+                }
+            }
+
+            return null;
+        }
+
+        private void NavigateToSearchTarget(SettingsSearchTarget target)
+        {
+            Type targetPageType = target.DetailPageType ?? GetPageTypeFromTag(target.RootTag);
+            _pendingBringIntoViewPageType = targetPageType;
+            _pendingBringIntoViewElementName = target.FocusElementName;
+
+            NavigationViewItem? rootItem = FindNavigationItemByTag(target.RootTag);
+            if (rootItem is not null && !ReferenceEquals(NavView.SelectedItem, rootItem))
+            {
+                NavView.SelectedItem = rootItem;
+            }
+            else
+            {
+                NavigateFromTag(target.RootTag);
+            }
+
+            if (target.DetailPageType is not null && ContentFrame.CurrentSourcePageType != target.DetailPageType)
+            {
+                ContentFrame.Navigate(target.DetailPageType);
+            }
+
+            TryBringPendingElementIntoView();
+        }
+
+        private NavigationViewItem? FindNavigationItemByTag(string rootTag)
+        {
+            foreach (object item in NavView.MenuItems)
+            {
+                if (item is NavigationViewItem navItem && string.Equals(navItem.Tag as string, rootTag, StringComparison.Ordinal))
+                {
+                    return navItem;
+                }
+            }
+
+            foreach (object item in NavView.FooterMenuItems)
+            {
+                if (item is NavigationViewItem navItem && string.Equals(navItem.Tag as string, rootTag, StringComparison.Ordinal))
+                {
+                    return navItem;
+                }
+            }
+
+            return null;
+        }
+
+        private void TryBringPendingElementIntoView()
+        {
+            if (_pendingBringIntoViewPageType is null || _pendingBringIntoViewPageType != ContentFrame.CurrentSourcePageType)
+            {
+                return;
+            }
+
+            string? elementName = _pendingBringIntoViewElementName;
+            _pendingBringIntoViewPageType = null;
+            _pendingBringIntoViewElementName = null;
+
+            if (string.IsNullOrWhiteSpace(elementName))
+            {
+                return;
+            }
+
+            if (ContentFrame.Content is FrameworkElement page
+                && page.FindName(elementName) is UIElement targetElement)
+            {
+                targetElement.StartBringIntoView();
+            }
+        }
+
+        private sealed class SettingsSearchTarget
+        {
+            internal SettingsSearchTarget(string displayText, string searchText, string rootTag, Type? detailPageType, string? focusElementName)
+            {
+                DisplayText = displayText;
+                SearchText = searchText;
+                RootTag = rootTag;
+                DetailPageType = detailPageType;
+                FocusElementName = focusElementName;
+            }
+
+            internal string DisplayText { get; }
+
+            internal string SearchText { get; }
+
+            internal string RootTag { get; }
+
+            internal Type? DetailPageType { get; }
+
+            internal string? FocusElementName { get; }
         }
     }
 }


### PR DESCRIPTION
## Summary by Sourcery

通过将设置窗口与原生标题栏集成并新增统一的设置搜索体验，同时使前端规范和资源与新的模式保持一致，从而实现现代化改造。

Enhancements:
- 将设置窗口与原生 `AppWindow` 标题栏集成，使用内置的返回和窗格切换按钮替代自绘控件。
- 添加跨整个设置的搜索体验，对各页面的关键选项进行索引，能够导航到相关部分并聚焦到对应控件。
- 引入共享的 `SettingsPage` 布局资源，用于在所有设置页面中统一间距和容器样式。

Documentation:
- 更新前端组件与质量规范，优先推荐使用原生 WinUI 控件，而非自绘的“伪原生”组件，并文档化共享的设置布局资源。
- 调整前端目录结构和示例，以反映 Import 对话框 XAML 的移除，以及新的导入与对话框使用模式。

Chores:
- 更新个人工作空间日志元数据，以记录新的开发会话和文件统计信息。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Modernize the settings window with native title bar integration and add a unified settings search experience, while aligning frontend guidelines and resources with the new patterns.

Enhancements:
- Integrate the settings window with the native AppWindow title bar, wiring built-in back and pane toggle buttons instead of custom-drawn controls.
- Add a settings-wide search experience that indexes key options across pages, navigates to the relevant section, and focuses the associated control.
- Introduce shared SettingsPage layout resources to standardize spacing and container styles across all settings pages.

Documentation:
- Update frontend component and quality guidelines to prioritize native WinUI controls over custom-drawn "pseudo-native" components and to document the shared settings layout resources.
- Adjust frontend directory structure and examples to reflect the removal of the Import dialog XAML and the new import and dialog usage patterns.

Chores:
- Update personal workspace journal metadata to record the new development sessions and file statistics.

</details>